### PR TITLE
Update ClickHouse port in environment example

### DIFF
--- a/agent_stack_builds/telco_marketing/.env.hybrid.example
+++ b/agent_stack_builds/telco_marketing/.env.hybrid.example
@@ -18,7 +18,7 @@ DEPLOY_MODE=hybrid
 # -----------------------------------------------------------------------------
 # Get these values from your ClickHouse Cloud console.
 CLICKHOUSE_HOST=your-instance.clickhouse.cloud
-CLICKHOUSE_PORT=8443
+CLICKHOUSE_PORT=9440
 CLICKHOUSE_USER=default
 CLICKHOUSE_PASSWORD=your-cloud-password
 CLICKHOUSE_SECURE=true


### PR DESCRIPTION
port is used by clickhouse-client, so default to 9440