### PR TITLE
upgrade: Langfuse v2 to v3.155.1 with reliability fixes

### DIFF
--- a/agent_stack_builds/telco_marketing/.env.local.example
+++ b/agent_stack_builds/telco_marketing/.env.local.example
@@ -35,10 +35,11 @@ LANGFUSE_DB_NAME=langfuse
 # Langfuse application settings
 LANGFUSE_URL=http://localhost:3000
 
-# Generate secure random values for these two fields:
+# Generate secure random values for these three fields:
 #   openssl rand -hex 32
 LANGFUSE_SECRET=<generate-with-openssl-rand-hex-32>
 LANGFUSE_SALT=<generate-with-openssl-rand-hex-32>
+LANGFUSE_ENCRYPTION_KEY=<generate-with-openssl-rand-hex-32>
 
 # Set to false to disable anonymous telemetry
 LANGFUSE_TELEMETRY=false
@@ -62,7 +63,7 @@ LANGFUSE_INIT_PROJECT_SECRET_KEY=<generate-langfuse-sk>
 # LibreChat reads these to connect to Langfuse (must match the INIT keys above)
 LANGFUSE_PUBLIC_KEY=<generate-langfuse-pk>
 LANGFUSE_SECRET_KEY=<generate-langfuse-sk>
-LANGFUSE_BASE_URL=http://langfuse:3000
+LANGFUSE_BASE_URL=http://langfuse-web:3000
 
 # -----------------------------------------------------------------------------
 # LibreChat Configuration

--- a/agent_stack_builds/telco_marketing/Makefile
+++ b/agent_stack_builds/telco_marketing/Makefile
@@ -53,6 +53,7 @@ setup-local:
 	@# Generate security keys
 	@LANGFUSE_SECRET=$$(openssl rand -hex 32) && \
 	 LANGFUSE_SALT=$$(openssl rand -hex 32) && \
+	 LANGFUSE_ENCRYPTION_KEY=$$(openssl rand -hex 32) && \
 	 CREDS_KEY=$$(openssl rand -hex 32) && \
 	 CREDS_IV=$$(openssl rand -hex 16) && \
 	 JWT_SECRET=$$(openssl rand -hex 32) && \
@@ -64,6 +65,9 @@ setup-local:
 	   .env && \
 	 sed -i.bak \
 	   -e "0,/<generate-with-openssl-rand-hex-32>/s||$$LANGFUSE_SALT|" \
+	   .env && \
+	 sed -i.bak \
+	   -e "0,/<generate-with-openssl-rand-hex-32>/s||$$LANGFUSE_ENCRYPTION_KEY|" \
 	   .env && \
 	 sed -i.bak \
 	   -e "0,/<generate-with-openssl-rand-hex-32>/s||$$CREDS_KEY|" \
@@ -160,15 +164,17 @@ start:
 	$(COMPOSE_CMD) up -d
 	@echo "[OK] Services started"
 	$(SERVICE_TABLE)
-	@echo "Waiting for services to be ready..."
-	@sleep 15
+	@echo "Waiting for LibreChat to be ready..."
+	@until docker inspect --format='{{.State.Health.Status}}' telco-librechat 2>/dev/null | grep -q healthy; do \
+		printf "."; sleep 3; \
+	done && echo " ready"
 	@# Create default workshop user (idempotent -- fails silently if user exists)
 	@LC_EMAIL=$$(grep -s '^LIBRECHAT_USER_EMAIL=' .env 2>/dev/null | cut -d= -f2) && \
 	 LC_NAME=$$(grep -s '^LIBRECHAT_USER_NAME=' .env 2>/dev/null | cut -d= -f2) && \
 	 LC_PASS=$$(grep -s '^LIBRECHAT_USER_PASSWORD=' .env 2>/dev/null | cut -d= -f2) && \
 	 LC_USER=$$(echo "$$LC_EMAIL" | cut -d@ -f1) && \
-	 echo "y" | docker exec -i telco-librechat sh -c \
-		"cd /app && node config/create-user.js $$LC_EMAIL $$LC_NAME $$LC_USER $$LC_PASS" \
+	 docker exec telco-librechat sh -c \
+		"cd /app && node config/create-user.js $$LC_EMAIL $$LC_NAME $$LC_USER $$LC_PASS --email-verified=true" \
 		>/dev/null 2>&1 && \
 		echo "[OK] Default user created: $$LC_EMAIL / $$LC_PASS" || \
 		echo "[OK] Default user already exists: $$LC_EMAIL / $$LC_PASS"

--- a/agent_stack_builds/telco_marketing/docker-compose.local.yml
+++ b/agent_stack_builds/telco_marketing/docker-compose.local.yml
@@ -24,7 +24,7 @@ services:
     networks:
       - telco-network
 
-  # ClickHouse Database (local)
+  # ClickHouse Database (local) - used by both telco demo and Langfuse
   clickhouse:
     image: clickhouse/clickhouse-server:25.8
     container_name: telco-clickhouse
@@ -65,21 +65,115 @@ services:
     networks:
       - telco-network
 
-  # Langfuse LLMOps Platform (local)
-  langfuse:
-    image: langfuse/langfuse:2
-    container_name: telco-langfuse
+  # Langfuse Redis (queue and caching)
+  langfuse-redis:
+    image: redis:7-alpine
+    container_name: telco-langfuse-redis
+    command: >
+      --requirepass ${LANGFUSE_REDIS_PASSWORD:-langfuse_redis}
+      --maxmemory-policy noeviction
+    volumes:
+      - langfuse_redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${LANGFUSE_REDIS_PASSWORD:-langfuse_redis}", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks:
+      - telco-network
+
+  # Langfuse MinIO (blob and event storage)
+  langfuse-minio:
+    image: cgr.dev/chainguard/minio
+    container_name: telco-langfuse-minio
+    entrypoint: sh
+    command: -c 'mkdir -p /data/langfuse && minio server --address ":9000" --console-address ":9001" /data'
+    environment:
+      MINIO_ROOT_USER: ${LANGFUSE_MINIO_USER:-minio}
+      MINIO_ROOT_PASSWORD: ${LANGFUSE_MINIO_PASSWORD:-miniosecret}
+    ports:
+      - "9090:9000"
+    volumes:
+      - langfuse_minio_data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+    networks:
+      - telco-network
+
+  # Langfuse Worker - background event processing
+  langfuse-worker:
+    image: langfuse/langfuse-worker:3.155.1
+    container_name: telco-langfuse-worker
+    restart: unless-stopped
     depends_on:
       langfuse-db:
+        condition: service_healthy
+      langfuse-redis:
+        condition: service_healthy
+      langfuse-minio:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+    environment: &langfuse-common-env
+      DATABASE_URL: postgresql://${LANGFUSE_DB_USER:-langfuse}:${LANGFUSE_DB_PASSWORD:-langfuse}@langfuse-db:5432/${LANGFUSE_DB_NAME:-langfuse}
+      NEXTAUTH_URL: ${LANGFUSE_URL:-http://localhost:3000}
+      SALT: ${LANGFUSE_SALT:-changeme-generate-a-secure-salt}
+      ENCRYPTION_KEY: ${LANGFUSE_ENCRYPTION_KEY:-0000000000000000000000000000000000000000000000000000000000000000}
+      TELEMETRY_ENABLED: ${LANGFUSE_TELEMETRY:-false}
+      LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES: ${LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES:-false}
+      # ClickHouse (shared with telco demo)
+      CLICKHOUSE_MIGRATION_URL: clickhouse://${CLICKHOUSE_USER:-default}:${CLICKHOUSE_PASSWORD:-clickhouse}@clickhouse:9000
+      CLICKHOUSE_URL: http://clickhouse:8123
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER:-default}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-clickhouse}
+      CLICKHOUSE_CLUSTER_ENABLED: "false"
+      # MinIO blob storage
+      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse
+      LANGFUSE_S3_EVENT_UPLOAD_REGION: auto
+      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: ${LANGFUSE_MINIO_USER:-minio}
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: ${LANGFUSE_MINIO_PASSWORD:-miniosecret}
+      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://langfuse-minio:9000
+      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_EVENT_UPLOAD_PREFIX: events/
+      LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: langfuse
+      LANGFUSE_S3_MEDIA_UPLOAD_REGION: auto
+      LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID: ${LANGFUSE_MINIO_USER:-minio}
+      LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: ${LANGFUSE_MINIO_PASSWORD:-miniosecret}
+      LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT: http://langfuse-minio:9000
+      LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_MEDIA_UPLOAD_PREFIX: media/
+      LANGFUSE_S3_BATCH_EXPORT_ENABLED: "false"
+      # Redis
+      REDIS_HOST: langfuse-redis
+      REDIS_PORT: 6379
+      REDIS_AUTH: ${LANGFUSE_REDIS_PASSWORD:-langfuse_redis}
+      REDIS_TLS_ENABLED: "false"
+    networks:
+      - telco-network
+
+  # Langfuse Web - UI and API
+  langfuse-web:
+    image: langfuse/langfuse:3.155.1
+    container_name: telco-langfuse-web
+    restart: unless-stopped
+    depends_on:
+      langfuse-db:
+        condition: service_healthy
+      langfuse-redis:
+        condition: service_healthy
+      langfuse-minio:
+        condition: service_healthy
+      clickhouse:
         condition: service_healthy
     ports:
       - "3000:3000"
     environment:
-      DATABASE_URL: postgresql://${LANGFUSE_DB_USER:-langfuse}:${LANGFUSE_DB_PASSWORD:-langfuse}@langfuse-db:5432/${LANGFUSE_DB_NAME:-langfuse}
-      NEXTAUTH_URL: ${LANGFUSE_URL:-http://localhost:3000}
+      <<: *langfuse-common-env
       NEXTAUTH_SECRET: ${LANGFUSE_SECRET:-changeme-generate-a-secure-secret}
-      SALT: ${LANGFUSE_SALT:-changeme-generate-a-secure-salt}
-      TELEMETRY_ENABLED: ${LANGFUSE_TELEMETRY:-false}
       # Headless initialization: auto-create org, project, user, and API keys
       LANGFUSE_INIT_ORG_ID: ${LANGFUSE_INIT_ORG_ID:-telco-workshop}
       LANGFUSE_INIT_ORG_NAME: ${LANGFUSE_INIT_ORG_NAME:-Telco Workshop}
@@ -93,10 +187,10 @@ services:
     networks:
       - telco-network
 
-  # Override: LiteLLM waits for Langfuse in local mode
+  # Override: LiteLLM waits for Langfuse web in local mode
   litellm:
     depends_on:
-      langfuse:
+      langfuse-web:
         condition: service_started
 
   # Override: data-generator depends on ClickHouse in local mode
@@ -109,4 +203,8 @@ volumes:
   clickhouse_data:
     driver: local
   langfuse_db_data:
+    driver: local
+  langfuse_redis_data:
+    driver: local
+  langfuse_minio_data:
     driver: local

--- a/agent_stack_builds/telco_marketing/docker-compose.yml
+++ b/agent_stack_builds/telco_marketing/docker-compose.yml
@@ -23,6 +23,12 @@ services:
     volumes:
       - ./.env:/app/.env
       - ./librechat.yaml:/app/librechat.yaml
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3080/api/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 15s
     networks:
       - telco-network
 
@@ -60,7 +66,7 @@ services:
       LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:-}
       LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-}
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-}
-      LANGFUSE_HOST: ${LANGFUSE_BASE_URL:-http://langfuse:3000}
+      LANGFUSE_HOST: ${LANGFUSE_BASE_URL:-http://langfuse-web:3000}
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:4000/health/readiness')"]
       interval: 10s


### PR DESCRIPTION
- Replace single langfuse:2 service with langfuse-web + langfuse-worker (v3 split architecture)
- Add langfuse-redis and langfuse-minio as required v3 dependencies
- Reuse existing ClickHouse for Langfuse v3 event storage
- Fix LANGFUSE_BASE_URL default (langfuse -> langfuse-web) to restore LiteLLM tracing
- Add LANGFUSE_ENCRYPTION_KEY to setup-local and .env.local.example (required in v3)
- Add LibreChat healthcheck so make start waits for true readiness before user creation
- Replace blind sleep 15 with until-healthy polling loop in Makefile
- Fix create-user.js call to pass --email-verified=true, eliminating readline race condition
- Fix setup-local sed chain to auto-generate LANGFUSE_ENCRYPTION_KEY on fresh installs