### PR TITLE
follow-up(telco_marketing): reorder setup flow + Windows-safe bind mounts

### DIFF
--- a/agent_stack_builds/telco_marketing/Makefile
+++ b/agent_stack_builds/telco_marketing/Makefile
@@ -97,8 +97,8 @@ setup-local:
 	@echo ""
 	@echo "Next steps:"
 	@echo "  1. Edit .env to set your GOOGLE_KEY (required for Gemini models)"
-	@echo "  2. make start"
-	@echo "  3. make generate-data"
+	@echo "  2. make generate-data"
+	@echo "  3. make start"
 	@echo "  4. Open http://localhost:3080 (LibreChat)"
 	@echo ""
 	@echo "Langfuse tracing is auto-configured. LibreChat sends traces directly to Langfuse."
@@ -142,8 +142,8 @@ setup-hybrid:
 	@echo "  3. Edit .env and fill in your Langfuse Cloud credentials (optional)"
 	@echo "  4. Edit .env and set your GOOGLE_KEY (required for Gemini models)"
 	@echo "  5. make init-schema"
-	@echo "  6. make start"
-	@echo "  7. make generate-data"
+	@echo "  6. make generate-data"
+	@echo "  7. make start"
 	@echo "  8. Open http://localhost:3080 (LibreChat)"
 
 # ---------------------------------------------------------------------------
@@ -287,5 +287,5 @@ clean:
 		$(COMPOSE_CMD) down -v --remove-orphans; \
 		rm -f librechat.yaml; \
 		echo "[OK] All services stopped, volumes removed, and generated files deleted."; \
-		echo "     To start fresh: make start && make generate-data"; \
+		echo "     To start fresh: make generate-data && make start"; \
 	fi

--- a/agent_stack_builds/telco_marketing/README.md
+++ b/agent_stack_builds/telco_marketing/README.md
@@ -179,8 +179,8 @@ Get up and running with everything in Docker:
 cd ClickHouse_Demos/agent_stack_builds/telco_marketing
 make setup-local
 # (Optional) Edit .env to set your LLM API key
-make start
 make generate-data
+make start
 make check-db
 ```
 
@@ -202,8 +202,8 @@ make setup-hybrid
 # Edit .env with your cloud credentials and LLM API key
 # Enable Remote MCP Server in ClickHouse Cloud console (Connect > Remote MCP Server)
 make init-schema
-make start
 make generate-data
+make start
 make check-db
 ```
 
@@ -255,21 +255,21 @@ Edit `.env` and set your Google API key:
 GOOGLE_KEY=your-google-api-key
 ```
 
-#### Step 3: Start Services
-
-```bash
-make start
-```
-
-This launches ClickHouse, Langfuse, LibreChat, the MCP server, and supporting services.
-
-#### Step 4: Generate Data
+#### Step 3: Generate Data
 
 ```bash
 make generate-data
 ```
 
-Populates ClickHouse with realistic telco data (takes 2-5 minutes for the default medium dataset).
+Brings up ClickHouse (which auto-loads the schema on first start in local mode), populates it with realistic telco data, then exits. Takes ~20-30 seconds for the default medium dataset.
+
+#### Step 4: Start Services
+
+```bash
+make start
+```
+
+This launches Langfuse, LibreChat, the MCP server, and the remaining supporting services. ClickHouse is already running from the previous step.
 
 #### Step 5: Verify
 
@@ -322,21 +322,21 @@ Push the database schema to your ClickHouse Cloud instance:
 make init-schema
 ```
 
-#### Step 4: Start Services
-
-```bash
-make start
-```
-
-This launches LibreChat and supporting services locally. The MCP connection to ClickHouse Cloud is handled by the remote MCP server.
-
-#### Step 5: Generate Data
+#### Step 4: Generate Data
 
 ```bash
 make generate-data
 ```
 
-The data generator connects to your ClickHouse Cloud instance and populates it.
+The data generator connects to your ClickHouse Cloud instance and populates it. Runs as a one-shot container; does not require LibreChat to be up.
+
+#### Step 5: Start Services
+
+```bash
+make start
+```
+
+This launches LibreChat and supporting services locally. The MCP connection to ClickHouse Cloud is handled by the remote MCP server, which now has the schema and data ready.
 
 #### Step 6: Use LibreChat
 
@@ -1586,8 +1586,8 @@ A `Makefile` is provided for easy management of the workshop environment. All co
 ```bash
 make setup-local
 # (Optional) Edit .env for LLM API keys
-make start
 make generate-data
+make start
 make check-db
 # Open http://localhost:3080
 ```
@@ -1598,8 +1598,8 @@ make check-db
 make setup-hybrid
 # Edit .env with cloud credentials + LLM API keys
 make init-schema
-make start
 make generate-data
+make start
 make check-db
 # Open http://localhost:3080
 ```

--- a/agent_stack_builds/telco_marketing/docker-compose.local.yml
+++ b/agent_stack_builds/telco_marketing/docker-compose.local.yml
@@ -33,7 +33,8 @@ services:
       - "9001:9000"
     volumes:
       - clickhouse_data:/var/lib/clickhouse
-      - ./clickhouse/init.sql:/docker-entrypoint-initdb.d/init.sql
+      # Quoted for Windows host paths that may contain spaces.
+      - "./clickhouse/init.sql:/docker-entrypoint-initdb.d/init.sql"
     environment:
       CLICKHOUSE_DB: telco
       CLICKHOUSE_USER: ${CLICKHOUSE_USER:-default}

--- a/agent_stack_builds/telco_marketing/docker-compose.yml
+++ b/agent_stack_builds/telco_marketing/docker-compose.yml
@@ -19,8 +19,10 @@ services:
     env_file:
       - .env
     volumes:
-      - ./.env:/app/.env
-      - ./librechat.${DEPLOY_MODE}.yaml:/app/librechat.yaml
+      # Bind-mount strings are quoted so they survive YAML parsing on Windows
+      # hosts where the resolved path may contain spaces (e.g. C:\Users\My Name\...).
+      - "./.env:/app/.env"
+      - "./librechat.${DEPLOY_MODE}.yaml:/app/librechat.yaml"
     healthcheck:
       test: ["CMD", "node", "-e", "require('http').get('http://localhost:3080/api/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"]
       interval: 5s


### PR DESCRIPTION
Follow-up to #16. Two independent commits.

## Summary

- **`docs(telco_marketing): run generate-data before make start`** — Reorder the setup flow so the database is populated before LibreChat starts. Data generator only needs ClickHouse (which the local override brings up via `service_healthy` dep; hybrid talks to Cloud), so it can run as a one-shot before the LibreChat side of the stack exists. Updates both Quick Start blocks, both Installation Steps sections, the Usage Examples block, and the Makefile "Next steps" echoes in `setup-local` / `setup-hybrid` + the clean-target hint.
- **`fix(telco_marketing): quote bind-mount volume strings for Windows hosts`** — Wrap the relative-path bind-mount volumes in double quotes so they survive YAML parsing on Windows hosts where the resolved path may contain spaces (e.g. `C:\Users\Some User\Documents\repo\librechat.hybrid.yaml`). Named volumes don't need quoting since they don't resolve to host paths.

## Test plan

- [ ] **Both modes**: `make setup-{local,hybrid}` "Next steps" output prints `generate-data` before `start`.
- [ ] **Hybrid**: `make init-schema && make generate-data && make start` completes; data lands in ClickHouse Cloud and LibreChat connects to it.
- [ ] **Local**: `make generate-data` brings up only the ClickHouse container (via service_healthy dep), populates it, exits. `make start` then brings up everything else with ClickHouse already healthy.
- [ ] **Windows path with spaces**: clone the repo into a directory containing a space and confirm `docker compose config` parses cleanly and `make start` mounts the bind volumes without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)