### PR TITLE
docs(telco_marketing): correct UUID capture instructions

### DIFF
--- a/agent_stack_builds/telco_marketing/.env.hybrid.example
+++ b/agent_stack_builds/telco_marketing/.env.hybrid.example
@@ -28,8 +28,10 @@ CLICKHOUSE_VERIFY=true
 # To pin the remote MCP server to a single org/service (so the LLM doesn't
 # enumerate everything before querying), edit librechat.hybrid.yaml's
 # `serverInstructions` block directly -- LibreChat does NOT substitute env
-# vars there. Grab the two UUIDs from the Cloud console URL:
-#   console.clickhouse.cloud/organizations/<ORG_UUID>/services/<SERVICE_UUID>
+# vars there. Grab the two UUIDs from the Cloud console:
+#   Service UUID:      console.clickhouse.cloud/services/<SERVICE_UUID>
+#   Organization UUID: console.clickhouse.cloud/organizations/<ORG_UUID>/...
+#                      (open the org switcher or visit Organization > Settings)
 
 # -----------------------------------------------------------------------------
 # Langfuse Cloud Configuration

--- a/agent_stack_builds/telco_marketing/.env.hybrid.example
+++ b/agent_stack_builds/telco_marketing/.env.hybrid.example
@@ -30,8 +30,8 @@ CLICKHOUSE_VERIFY=true
 # `serverInstructions` block directly -- LibreChat does NOT substitute env
 # vars there. Grab the two UUIDs from the Cloud console:
 #   Service UUID:      console.clickhouse.cloud/services/<SERVICE_UUID>
-#   Organization UUID: console.clickhouse.cloud/organizations/<ORG_UUID>/...
-#                      (open the org switcher or visit Organization > Settings)
+#   Organization UUID: console.clickhouse.cloud/organizations/<ORG_UUID>
+#                      (open Organization > Settings)
 
 # -----------------------------------------------------------------------------
 # Langfuse Cloud Configuration

--- a/agent_stack_builds/telco_marketing/README.md
+++ b/agent_stack_builds/telco_marketing/README.md
@@ -307,7 +307,7 @@ make setup-hybrid
 
 Edit `.env` and fill in:
 
-- **ClickHouse Cloud**: `CLICKHOUSE_HOST`, `CLICKHOUSE_PORT`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`. To pin the LLM to a single org/service (so it skips discovery), edit `librechat.hybrid.yaml`'s `serverInstructions` block directly with the two UUIDs from the Cloud console URL — LibreChat doesn't substitute env vars there.
+- **ClickHouse Cloud**: `CLICKHOUSE_HOST`, `CLICKHOUSE_PORT`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`. To pin the LLM to a single org/service (so it skips discovery), edit `librechat.hybrid.yaml`'s `serverInstructions` block directly with the two UUIDs — service UUID from the service-page URL, organization UUID from the org switcher / Organization → Settings page. LibreChat doesn't substitute env vars in `serverInstructions`.
 - **Langfuse Cloud** (optional): `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`
 - **LLM key**: `ANTHROPIC_API_KEY` (the hybrid presets target Claude 4.6 / Haiku 3.5)
 

--- a/agent_stack_builds/telco_marketing/README.md
+++ b/agent_stack_builds/telco_marketing/README.md
@@ -307,7 +307,7 @@ make setup-hybrid
 
 Edit `.env` and fill in:
 
-- **ClickHouse Cloud**: `CLICKHOUSE_HOST`, `CLICKHOUSE_PORT`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`. To pin the LLM to a single org/service (so it skips discovery), edit `librechat.hybrid.yaml`'s `serverInstructions` block directly with the two UUIDs — service UUID from the service-page URL, organization UUID from the org switcher / Organization → Settings page. LibreChat doesn't substitute env vars in `serverInstructions`.
+- **ClickHouse Cloud**: `CLICKHOUSE_HOST`, `CLICKHOUSE_PORT`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`. To pin the LLM to a single org/service (so it skips discovery), edit `librechat.hybrid.yaml`'s `serverInstructions` block directly with the two UUIDs — service UUID from the service-page URL, organization UUID from **Organization → Settings** (`console.clickhouse.cloud/organizations/<ORG_UUID>`). LibreChat doesn't substitute env vars in `serverInstructions`.
 - **Langfuse Cloud** (optional): `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`
 - **LLM key**: `ANTHROPIC_API_KEY` (the hybrid presets target Claude 4.6 / Haiku 3.5)
 

--- a/agent_stack_builds/telco_marketing/WORKSHOP_HYBRID_SETUP.html
+++ b/agent_stack_builds/telco_marketing/WORKSHOP_HYBRID_SETUP.html
@@ -586,15 +586,15 @@ html, body { background: var(--canvas); }
     <li>Log in to <a href="https://console.clickhouse.cloud">console.clickhouse.cloud</a></li>
     <li>Create or pick a service — free <strong>Development</strong> tier works</li>
     <li><strong>Connect</strong> → <strong>HTTPS</strong> → grab host and password</li>
-    <li>Read both UUIDs straight from the URL:</li>
+    <li><strong>Service UUID</strong> — read from the service page URL: <code>console.clickhouse.cloud/services/&lt;SERVICE_UUID&gt;</code></li>
+    <li><strong>Organization UUID</strong> — open the org switcher in the top-left, or visit <strong>Organization → Settings</strong>; the URL will be <code>/organizations/&lt;ORG_UUID&gt;/…</code></li>
   </ol>
-  <pre><code class="language-text">https://console.clickhouse.cloud/organizations/ORG_UUID/services/SERVICE_UUID</code></pre>
   <div class="callout">
     Save both UUIDs — they go directly into <code>librechat.hybrid.yaml</code> in Step 06, <strong>not into <code>.env</code></strong> (LibreChat doesn't substitute env vars in <code>serverInstructions</code>).
   </div>
   <aside class="notes">
-    Live-demo the URL inspection on screen — it's the fastest way to grab the
-    org/service UUIDs.
+    Service UUID is in the service-page URL. Org UUID is NOT in the service URL —
+    grab it from the org switcher dropdown or the Organization settings page.
   </aside>
 </section>
 

--- a/agent_stack_builds/telco_marketing/WORKSHOP_HYBRID_SETUP.html
+++ b/agent_stack_builds/telco_marketing/WORKSHOP_HYBRID_SETUP.html
@@ -586,15 +586,15 @@ html, body { background: var(--canvas); }
     <li>Log in to <a href="https://console.clickhouse.cloud">console.clickhouse.cloud</a></li>
     <li>Create or pick a service — free <strong>Development</strong> tier works</li>
     <li><strong>Connect</strong> → <strong>HTTPS</strong> → grab host and password</li>
-    <li><strong>Service UUID</strong> — read from the service page URL: <code>console.clickhouse.cloud/services/&lt;SERVICE_UUID&gt;</code></li>
-    <li><strong>Organization UUID</strong> — open the org switcher in the top-left, or visit <strong>Organization → Settings</strong>; the URL will be <code>/organizations/&lt;ORG_UUID&gt;/…</code></li>
+    <li><strong>Service UUID</strong> — from the service-page URL: <code>console.clickhouse.cloud/services/&lt;SERVICE_UUID&gt;</code></li>
+    <li><strong>Organization UUID</strong> — open <strong>Organization → Settings</strong> in the console. The URL becomes <code>console.clickhouse.cloud/organizations/&lt;ORG_UUID&gt;</code>.</li>
   </ol>
   <div class="callout">
     Save both UUIDs — they go directly into <code>librechat.hybrid.yaml</code> in Step 06, <strong>not into <code>.env</code></strong> (LibreChat doesn't substitute env vars in <code>serverInstructions</code>).
   </div>
   <aside class="notes">
     Service UUID is in the service-page URL. Org UUID is NOT in the service URL —
-    grab it from the org switcher dropdown or the Organization settings page.
+    grab it from Organization → Settings.
   </aside>
 </section>
 

--- a/agent_stack_builds/telco_marketing/WORKSHOP_HYBRID_SETUP.md
+++ b/agent_stack_builds/telco_marketing/WORKSHOP_HYBRID_SETUP.md
@@ -63,9 +63,9 @@ You'll need eight values total. Write them in a scratch buffer as you go.
      ```
      https://console.clickhouse.cloud/services/<SERVICE_UUID>
      ```
-   - **Organization UUID** — open the org switcher in the top-left of the console, or visit **Organization → Settings**. The URL becomes:
+   - **Organization UUID** — open **Organization → Settings** in the console. The URL becomes:
      ```
-     https://console.clickhouse.cloud/organizations/<ORG_UUID>/...
+     https://console.clickhouse.cloud/organizations/<ORG_UUID>
      ```
    Save **both**. They go straight into `librechat.hybrid.yaml` (Step 6) — not `.env`. They pin the remote MCP server to your one service so the LLM doesn't enumerate every org/service before querying.
 

--- a/agent_stack_builds/telco_marketing/WORKSHOP_HYBRID_SETUP.md
+++ b/agent_stack_builds/telco_marketing/WORKSHOP_HYBRID_SETUP.md
@@ -58,10 +58,15 @@ You'll need eight values total. Write them in a scratch buffer as you go.
 4. Pick the **HTTPS** tab. Note:
    - `CLICKHOUSE_HOST` — the hostname like `xxxxxxxxxx.region.aws.clickhouse.cloud`
    - `CLICKHOUSE_PASSWORD` — shown once at service creation (or reset under Settings → Connections)
-5. From the URL of the service page, grab the two UUIDs:
-   ```
-   https://console.clickhouse.cloud/organizations/<ORG_UUID>/services/<SERVICE_UUID>
-   ```
+5. Grab the two UUIDs from two different places:
+   - **Service UUID** — from the service-page URL:
+     ```
+     https://console.clickhouse.cloud/services/<SERVICE_UUID>
+     ```
+   - **Organization UUID** — open the org switcher in the top-left of the console, or visit **Organization → Settings**. The URL becomes:
+     ```
+     https://console.clickhouse.cloud/organizations/<ORG_UUID>/...
+     ```
    Save **both**. They go straight into `librechat.hybrid.yaml` (Step 6) — not `.env`. They pin the remote MCP server to your one service so the LLM doesn't enumerate every org/service before querying.
 
 ### 1b. Langfuse Cloud


### PR DESCRIPTION
Follow-up to #20. Two commits:

1. **`d58d40f` (cherry-picked)** — service-page URL only contains the service UUID, not the organization UUID; instructions split into two paths.
2. **HEAD** — refine the org-UUID step to point at exactly **Organization → Settings**, which lands on \`console.clickhouse.cloud/organizations/<ORG_UUID>\` with no trailing path.

Affects `.env.hybrid.example`, `README.md`, `WORKSHOP_HYBRID_SETUP.md`, and `WORKSHOP_HYBRID_SETUP.html` (slide 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)