### PR TITLE
workshop: remove Supabase self-paced fallback from module 03 CDC

### DIFF
--- a/workshops/build_workshop/docs/WORKSHOP_PLAN_V2.md
+++ b/workshops/build_workshop/docs/WORKSHOP_PLAN_V2.md
@@ -79,7 +79,7 @@ on slips. THIS is where the slot gate lives: 30+ pipes on one instance needs
 max_replication_slots/max_wal_senders raised to ~50 and max_connections to 300+ — and on
 managed Postgres that patch is a known beta gap (FORBIDDEN; raise via console/support),
 so the documented fallback-of-the-fallback is **RDS** (custom parameter group, slots to
-50, ~$0.07/hr) or **Supabase** (CLI-settable slots, DIRECT connection not the pooler).
+50, ~$0.07/hr; use the DIRECT connection, not the pooler).
 Neon is ruled out (slots fixed at 10, inactive slots deleted after ~40h). No
 PgBouncer/pooler in the CDC path. The `max_slot_wal_keep_size` WAL safety valve is
 best-effort only: it reads back as -1 (unlimited) on live managed instances because the
@@ -180,7 +180,7 @@ stranded; hard pivot rules at 1:30 and 2:45.
 1. PRIMARY (D1) gate: can a fresh TRIAL org create a managed Postgres instance
    (`clickhousectl cloud postgres create`) and reach it via psql? Verify at the dry run
    on a clean trial org — this is the gate that matters now. FALLBACK gate: on one
-   shared instance, are slots raisable to 50 for 30+ pipes? (else RDS/Supabase.)
+   shared instance, are slots raisable to 50 for 30+ pipes? (else RDS.)
 2. 10 concurrent ClickPipes CDC against the shared PG: snapshot contention, slot
    stability, decode CPU. (D2 gate; now relevant only to the shared FALLBACK pool —
    the primary path is one pipe per own instance — else S3-pipe fallback.)

--- a/workshops/build_workshop/infra/README.md
+++ b/workshops/build_workshop/infra/README.md
@@ -109,12 +109,11 @@ Postgres Settings tab or ClickHouse support. `verify-pg` prints this same hint o
 - `slips.txt` — printable hand-outs: the `.env.workshop` PG block, the ClickPipe
   wizard values, and an optional chctl one-liner per participant
 
-## Using another Postgres provider (RDS, Supabase, ...)
+## Using another Postgres provider (RDS, ...)
 
 Skip `create-pg`/`configure-pg`; create the instance there and apply the same
-targets (RDS: custom parameter group + `rds.logical_replication=1`; Supabase:
-`supabase postgres-config update ... --experimental`, and use the DIRECT
-endpoint — poolers are not supported for CDC). Then export the `ADMIN_PG*`
+targets (RDS: custom parameter group + `rds.logical_replication=1`). Use the DIRECT
+endpoint — poolers are not supported for CDC. Then export the `ADMIN_PG*`
 variables and use `provision`/`verify-pg`/`create-pipe`/`verify-sync`/`teardown`
 unchanged.
 

--- a/workshops/build_workshop/infra/provision_workshop_stack.sh
+++ b/workshops/build_workshop/infra/provision_workshop_stack.sh
@@ -23,7 +23,7 @@
 # Auth: org API key (write ops; browser OAuth is read-only):
 #   export CLICKHOUSE_CLOUD_API_KEY=...  CLICKHOUSE_CLOUD_API_SECRET=...
 #
-# Admin Postgres connection (after create-pg, or your own RDS/Supabase):
+# Admin Postgres connection (after create-pg, or your own RDS):
 #   ADMIN_PGHOST (required) ADMIN_PGPASSWORD (required)
 #   ADMIN_PGPORT=5432 ADMIN_PGUSER=postgres ADMIN_PGDATABASE=postgres ADMIN_PGSSLMODE=require
 #

--- a/workshops/build_workshop/playbook/content/docs/learner/03-realtime-cdc.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/03-realtime-cdc.mdx
@@ -214,38 +214,10 @@ You should see the ClickPipe in the console (Console - **Data sources**) reporti
 **Running** state, and `SELECT count() FROM nyc_tlc_data.realtime_trips` climbing each
 time you re-run it.
 
-<Callout type="warn" title="Fallback: no managed Postgres in your org">
-  Managed Postgres is in beta and availability varies by org. If
-  `clickhousectl cloud postgres create` is not available to you, use one of these two
-  sources instead — everything else in this module is identical.
-
-  **No instructor (self-paced): a free Supabase project.** Sign up at
-  [supabase.com](https://supabase.com) and create a new project, saving the database
-  password you set at creation — that is the `postgres` user's password. In the project's
-  connection settings, copy the **direct** connection details (host `db.<ref>.supabase.co`,
-  port `5432`), **not** the connection pooler — poolers do not support the logical
-  replication that CDC needs. Put them in the same `.env.workshop` fields: `PGHOST` (the
-  direct host), `PGPORT=5432`, `PGDATABASE=postgres`, `PGUSER=postgres`,
-  `PGPASSWORD=<your project password>`, `PGSSLMODE=require`, `PG_PUBLICATION=pub_taxi`.
-  Because you connect as the project's `postgres` user, the generator creates the
-  `realtime_trips` table and the `pub_taxi` publication itself on first run, exactly like
-  the primary path. When you create the ClickPipe (Step 3), pick the dedicated **Supabase**
-  source type in the wizard (or pass `--postgres-type supabase` on the CLI) so it uses the
-  right connection settings.
-
-  **In the room: the instructor's shared-Postgres slip.** Use the slip's values in the same
-  `.env.workshop` and ClickPipe fields — `PGHOST`, `PGDATABASE` (named `taxi_pNN`),
-  `PGUSER`, `PGPASSWORD`, `PGSSLMODE=require`, and set `PG_PUBLICATION` to the slip's
-  publication (`pub_taxi_pNN`). On the shared instance the table and publication are
-  pre-created for you, so the generator log shows `publication ... already exists` instead
-  of creating one — that is expected.
-</Callout>
-
 ## How to verify you are done
 
 - The generator log shows your managed instance reachable and the publication ready
-  (`created publication pub_taxi` on your own instance, or `already exists` on the shared
-  fallback), followed by `inserted N trips`.
+  (`created publication pub_taxi`), followed by `inserted N trips`.
 - The ClickPipe shows an active, replicating state in the console.
 - The destination table row count in ClickHouse increases over time.
 - The Ops dashboard updates without a manual refresh.

--- a/workshops/build_workshop/playbook/content/docs/learner/self-paced.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/self-paced.mdx
@@ -14,13 +14,9 @@ create your own ClickHouse Cloud trial, your own Postgres managed by ClickHouse 
 `clickhousectl` (module 03), and your own API keys - there is no shared resource you
 depend on. Modules 04 through 09 are the same.
 
-An instructor normally provides three things, and each has a self-serve replacement built
+An instructor normally provides two things, and each has a self-serve replacement built
 into these materials:
 
-- **The shared-Postgres fallback slip** (module 03), for anyone whose org cannot create a
-  managed Postgres, is replaced by the self-serve CDC fallback: create a free Supabase
-  project as the source. The steps are in the fallback callout in
-  [03 Real-time CDC](/docs/learner/03-realtime-cdc).
 - **The staffed setup clinic** (module 00) is replaced by `./preflight.sh`, which checks
   everything the live bring-up trips over, and the [Troubleshooting](/docs/learner/troubleshooting)
   page, which lists every failure seen in testing with its exact fix.


### PR DESCRIPTION
## What

Removes the **"Fallback: no managed Postgres in your org"** callout from module 03 (Real-time CDC) and strips every remaining **Supabase** mention across the workshop, keeping **RDS** as the documented alternative Postgres provider.

## Changes

- **`03-realtime-cdc.mdx`** — delete the entire fallback callout (both the Supabase self-paced path and the instructor shared-Postgres slip); simplify the *How to verify* line that referenced the shared fallback.
- **`self-paced.mdx`** — drop the now-stale Supabase fallback bullet; "three things" → "two things".
- **`infra/README.md`** — "Using another Postgres provider" section keeps RDS and the general "use the DIRECT endpoint, poolers not supported for CDC" warning; drops Supabase.
- **`infra/provision_workshop_stack.sh`** — comment now reads `your own RDS` (was `RDS/Supabase`).
- **`docs/WORKSHOP_PLAN_V2.md`** — fallback-of-the-fallback and the verification gate now list RDS only.

## Verification

`grep -rin supabase` over the workshop returns nothing.

## Note (not changed)

`troubleshooting.mdx` still mentions the "shared fallback" pool in two places (lines ~104 and ~125). Those point at the shared-Postgres **pool** / `infra/README.md`, which still exists — they don't reference the removed module-03 callout — so I left them. Let me know if you'd like those trimmed too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)