### PR TITLE
playbook(learner 01): polish Steps 2 and 5

### DIFF
--- a/workshops/build_workshop/playbook/content/docs/learner/01-clickhouse-cloud.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/01-clickhouse-cloud.mdx
@@ -43,18 +43,21 @@ CLICKHOUSE_SECURE=true
 
 ### `db/cloud/001_cloud_schema.sql`
 
-The workshop ships an idempotent schema file. First create the destination database,
-then run the schema against your service (Cloud SQL console, `clickhousectl`, or your
-agent):
+The workshop ships an idempotent schema file. It creates the destination database
+(`CREATE DATABASE IF NOT EXISTS nyc_tlc_data`) and all the base objects in one go, so you
+can run it as a single command against your service:
 
-```sql
-CREATE DATABASE IF NOT EXISTS nyc_tlc_data;
--- then run db/cloud/001_cloud_schema.sql, which creates the base objects:
---   taxi_zones, fhv_trips, taxi_trips           (ENGINE = MergeTree; Cloud backs these
---                                                 with SharedMergeTree transparently, so
---                                                 no ON CLUSTER / Replicated* is needed)
---   taxi_trips_expanded, fhv_trips_expanded     (enrichment views)
+```bash
+clickhouse client --host <your-service>.<region>.<cloud>.clickhouse.cloud --port 9440 --secure \
+  --user default --password '<password>' --multiquery < db/cloud/001_cloud_schema.sql
 ```
+
+Or paste the file into the Cloud SQL console (or run it with `clickhousectl` or your
+agent). It creates the base objects:
+
+- `taxi_zones`, `fhv_trips`, `taxi_trips` — `ENGINE = MergeTree` (Cloud backs these with
+  SharedMergeTree transparently, so no `ON CLUSTER` / `Replicated*` is needed)
+- `taxi_trips_expanded`, `fhv_trips_expanded` — enrichment views
 
 <Callout>
   `001_cloud_schema.sql` creates only the base tables and views, and runs cleanly on its

--- a/workshops/build_workshop/playbook/content/docs/learner/01-clickhouse-cloud.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/01-clickhouse-cloud.mdx
@@ -118,8 +118,40 @@ idle-scale to zero and take a few seconds to wake.)
 
 Open the Historical dashboard. Now that ClickHouse Cloud is seeded, the charts render —
 try a wide date range and watch the seeded historical data (a few million rows) come back
-in well under a second. Then ask your agent your own analytical question against the
-data — this is your open step.
+in well under a second.
+
+Then ask your agent your own analytical question against the data — this is your open
+step. If you want a starting point, here are a few questions that work well against the
+seeded month:
+
+- "Which pickup zones had the most yellow-taxi trips, and what was the average fare?"
+- "What's the busiest hour of the day for pickups?"
+- "How does the average tip percentage differ by borough?"
+
+For example, that first question maps to a query like this — a join across ~3.2M trips
+and the 265 zones that still returns in well under a second:
+
+```sql
+SELECT
+  z.zone    AS pickup_zone,
+  z.borough AS borough,
+  count()                                              AS trips,
+  round(avg(t.fare_amount), 2)                         AS avg_fare,
+  round(avg(t.tip_amount / nullIf(t.fare_amount, 0)) * 100, 1) AS avg_tip_pct
+FROM nyc_tlc_data.taxi_trips AS t
+INNER JOIN nyc_tlc_data.taxi_zones AS z
+  ON t.pickup_location_id = z.location_id
+GROUP BY pickup_zone, borough
+ORDER BY trips DESC
+LIMIT 10;
+```
+
+<Callout>
+  The seed loads a single month (July 2022), so even a "wide" date range in the dashboard
+  covers that one month — still a few million rows per query, which is plenty to feel how
+  fast ClickHouse aggregates. Add more months by copying statement 2 in
+  `db/cloud/002_seed_historical.sql` with the next month's file name.
+</Callout>
 
 ## How to verify you are done
 


### PR DESCRIPTION
## What

Two learner-facing polish fixes to the `01-clickhouse-cloud` module, both flagged on the [live page](https://dev.demohouse.cloud/workshop/docs/learner/01-clickhouse-cloud).

### Step 2 — single copy-paste schema command
Step 2 described running the schema (console / `clickhousectl` / agent) but, unlike Step 3, gave no runnable one-liner. Added the same `clickhouse client --multiquery` command pointed at `db/cloud/001_cloud_schema.sql`. The file already begins with `CREATE DATABASE IF NOT EXISTS nyc_tlc_data`, so it runs as a single self-contained command — reframed the intro accordingly and moved the created-objects list to a bullet list.

### Step 5 — worked example
Step 5 ("Feel the query speed") told learners to *"ask your agent your own analytical question"* but gave no concrete starting point. Added:
- **Three example questions** (busiest pickup zones, busiest hour, tip % by borough) as a starting point.
- **One runnable SQL query** — `taxi_trips` joined to `taxi_zones` — verified against the real schema in `app/db/cloud/001_cloud_schema.sql` (joins `pickup_location_id`→`location_id`; guards the tip-% division with `nullIf(fare_amount, 0)` since the amount columns are `Nullable(Float64)`).
- **A `<Callout>`** noting the seed is a single month (July 2022), so a "wide" date range still covers just that month, plus a pointer to `db/cloud/002_seed_historical.sql` for loading more.

## Notes

- Docs-only change (one MDX file); the live site updates on the next playbook rebuild/deploy.
- The parallel **instructor** page (`playbook/content/docs/instructor/01-clickhouse-cloud.mdx`) was left untouched — happy to add matching parity in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)