### PR TITLE
workshop: remove the unused pgadmin service

### DIFF
--- a/workshops/build_workshop/app/.env.workshop.example
+++ b/workshops/build_workshop/app/.env.workshop.example
@@ -118,14 +118,9 @@ CREDS_IV=e2341419ec3dd3d19b13a1a87fafcbfb
 BACKEND_HOST_PORT=8000
 FRONTEND_HOST_PORT=8080
 POSTGRES_HOST_PORT=5432
-PGADMIN_HOST_PORT=5050
 
 # === Backend query safety limits (rarely changed) ==========================
 API_CORS_ORIGINS=http://localhost:5173,http://localhost:8080
 QUERY_TIMEOUT_SECONDS=5
 MAX_ROWS_TO_READ=200000000
 MAX_BYTES_TO_READ=5000000000
-
-# === pgadmin (only with `--profile tools`) =================================
-PGADMIN_DEFAULT_EMAIL=admin@example.com
-PGADMIN_DEFAULT_PASSWORD=admin

--- a/workshops/build_workshop/app/README.md
+++ b/workshops/build_workshop/app/README.md
@@ -30,7 +30,6 @@ Host ports (override any of these in `.env.workshop` if it is already taken —
 | Frontend (UI) | 8080 | `FRONTEND_HOST_PORT` |
 | Backend API | 8000 | `BACKEND_HOST_PORT` |
 | Postgres (local fallback) | 5432 | `POSTGRES_HOST_PORT` |
-| pgAdmin (`--profile tools`) | 5050 | `PGADMIN_HOST_PORT` |
 | OTel gRPC (otel overlay) | 4317 | `OTEL_GRPC_HOST_PORT` |
 | OTel HTTP (otel overlay) | 4318 | `OTEL_HTTP_HOST_PORT` |
 

--- a/workshops/build_workshop/app/WORKSHOP_CHANGES.md
+++ b/workshops/build_workshop/app/WORKSHOP_CHANGES.md
@@ -49,8 +49,7 @@ Contains only:
 - `postgres` -- local fallback only (kept `wal_level=logical` for parity);
 - `backend` -- all ClickHouse params env-driven, defaulting to `8443` + TLS;
 - `frontend` -- unchanged build, nginx still proxies `/api` to `backend:8000`;
-- `pg-trip-writer` -- the loadgen, PG connection env-driven, throttled;
-- `pgadmin` -- optional, only starts with `--profile tools`.
+- `pg-trip-writer` -- the loadgen, PG connection env-driven, throttled.
 
 Deliberately **omitted**: `clickhouse`, `ch-ui`, `broker`, `connect`,
 `kafka-ui`, `pg-cdc-init`, `clickhouse-cdc-init`, `connect-init`. ClickHouse is
@@ -214,14 +213,12 @@ plain HTTP (secure inferred `false` from the port).
    ```
 
    App on http://localhost:8080, backend API on http://localhost:8000.
-   Add `--profile tools` to also start pgadmin on http://localhost:5050.
 
 ## Verification performed
 
 - `docker compose -f docker-compose.workshop.yml config` passes with **exit 0
   and no warnings** with no `.env` file, and again with a filled `--env-file`.
-  With the profile off, only `backend`, `frontend`, `postgres`,
-  `pg-trip-writer` are present; `pgadmin` appears only with `--profile tools`.
+  Only `backend`, `frontend`, `postgres`, and `pg-trip-writer` are present.
   Env interpolation was confirmed (e.g. `CLICKHOUSE_SECURE: "true"`, filled
   `CLICKHOUSE_HOST`, `PGHOST`, `RATE_PER_SEC`, and `PGSSLMODE` defaulting to
   `prefer` and overriding to `require`).

--- a/workshops/build_workshop/app/docker-compose.workshop.yml
+++ b/workshops/build_workshop/app/docker-compose.workshop.yml
@@ -15,8 +15,6 @@
 #   # fill in your ClickHouse Cloud endpoint/password (and shared Postgres, if used)
 #   docker compose --env-file .env.workshop -f docker-compose.workshop.yml up -d
 #
-# pgadmin is optional and only starts with:  --profile tools
-#
 # This file is self-contained: it does NOT extend docker-compose.yml.
 
 services:
@@ -150,23 +148,5 @@ services:
       - BATCH_SIZE=${BATCH_SIZE:-10}
     restart: unless-stopped
 
-  # Optional: only starts with `--profile tools`. Handy for inspecting the
-  # local fallback Postgres; not needed for the shared managed Postgres.
-  pgadmin:
-    image: dpage/pgadmin4:9.11.0
-    container_name: nyc-taxi-workshop-pgadmin
-    profiles: ["tools"]
-    depends_on:
-      - postgres
-    environment:
-      - PGADMIN_DEFAULT_EMAIL=${PGADMIN_DEFAULT_EMAIL:-admin@example.com}
-      - PGADMIN_DEFAULT_PASSWORD=${PGADMIN_DEFAULT_PASSWORD:-admin}
-      - PGADMIN_LISTEN_PORT=80
-    ports:
-      - "${PGADMIN_HOST_PORT:-5050}:80"
-    volumes:
-      - pgadmin_data:/var/lib/pgadmin
-
 volumes:
   postgres_data:
-  pgadmin_data:

--- a/workshops/build_workshop/app/preflight.sh
+++ b/workshops/build_workshop/app/preflight.sh
@@ -181,7 +181,7 @@ resolve_port() {
 
 # check_port VAR PORT SEVERITY NOTE -- probe one host port.
 # SEVERITY is "core" (a real conflict FAILs) or "optional" (WARN only, since the
-# port is bound solely when you opt into --profile tools / the otel overlay).
+# port is bound solely when you opt into the otel overlay).
 check_port() {
   local var="$1" port="$2" sev="$3" note="$4"
   if port_in_use "$port"; then
@@ -408,7 +408,7 @@ else
   fail ".env.workshop not found in $SCRIPT_DIR" \
        "run: cp .env.workshop.example .env.workshop  then fill in CLICKHOUSE_HOST and CLICKHOUSE_PASSWORD"
   if [ -f "$EXAMPLE_FILE" ]; then
-    warn "port checks below use the example defaults (8080/8000/5432/5050/4317/4318)" \
+    warn "port checks below use the example defaults (8080/8000/5432/4317/4318)" \
          "create .env.workshop so preflight checks your real, effective ports"
   fi
 fi
@@ -429,14 +429,12 @@ section "Host port availability (effective ports)"
 FRONTEND_PORT=$(resolve_port FRONTEND_HOST_PORT 8080)
 BACKEND_PORT=$(resolve_port BACKEND_HOST_PORT 8000)
 POSTGRES_PORT=$(resolve_port POSTGRES_HOST_PORT 5432)
-PGADMIN_PORT=$(resolve_port PGADMIN_HOST_PORT 5050)
 OTEL_GRPC_PORT=$(resolve_port OTEL_GRPC_HOST_PORT 4317)
 OTEL_HTTP_PORT=$(resolve_port OTEL_HTTP_HOST_PORT 4318)
 
 check_port FRONTEND_HOST_PORT "$FRONTEND_PORT" core ""
 check_port BACKEND_HOST_PORT "$BACKEND_PORT" core ""
 check_port POSTGRES_HOST_PORT "$POSTGRES_PORT" core ""
-check_port PGADMIN_HOST_PORT "$PGADMIN_PORT" optional " (only with --profile tools)"
 check_port OTEL_GRPC_HOST_PORT "$OTEL_GRPC_PORT" optional " (only with the otel overlay)"
 check_port OTEL_HTTP_HOST_PORT "$OTEL_HTTP_PORT" optional " (only with the otel overlay)"
 

--- a/workshops/build_workshop/playbook/content/docs/learner/00-setup.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/00-setup.mdx
@@ -418,9 +418,7 @@ docker compose --env-file .env.workshop -f docker-compose.workshop.yml up -d
 ```
 
 Give it a couple of minutes to become healthy, then open
-[localhost:8080](http://localhost:8080) (or your overridden `FRONTEND_HOST_PORT`). Add
-`--profile tools` to the command to also start pgadmin on
-[localhost:5050](http://localhost:5050).
+[localhost:8080](http://localhost:8080) (or your overridden `FRONTEND_HOST_PORT`).
 
 You should see, after `docker compose ps`, every workshop service with a `STATUS` of
 `healthy` (it reads `Up` for the first ~30s while still starting), and the front end


### PR DESCRIPTION
## What

Removes the `pgadmin` service from the workshop stack, plus every config and doc reference to it.

## Why

pgadmin was **inherited scaffold** from the upstream demo's compose (it arrived in the very first `de36843` "foundation app" commit), not something added for a workshop purpose. In the current Cloud + managed-Postgres design it earns its keep nowhere:

- It was gated behind `--profile tools`, so it **never started by default**.
- It `depends_on: postgres` and could only reach the **local fallback** `postgres` container on the docker network — not the managed Postgres created in module 03.
- It was **not pre-wired** to any server (no `servers.json`), so even when started it opened empty.
- **No running service depends on it** — it's a leaf.

So it's dead weight that only added confusion (an extra service, an extra port in preflight, an extra `--profile tools` tip).

## Changes

- **`docker-compose.workshop.yml`** — drop the `pgadmin` service, the `pgadmin_data` volume, and the header note.
- **`preflight.sh`** — drop the optional port-5050 check and `PGADMIN_PORT`; fix the now-stale `--profile tools` comments (pgadmin was the only service in that profile).
- **`.env.workshop.example`** — drop `PGADMIN_HOST_PORT` and the pgadmin credentials block.
- **`README.md`** — drop the pgAdmin row from the port table.
- **`playbook/.../learner/00-setup.mdx`** — drop the "add `--profile tools` to also start pgadmin" tip in Step 10.
- **`WORKSHOP_CHANGES.md`** — update the service inventory and verification note.

## Scope / follow-up

Deliberately **out of scope**: the local `postgres` container and the `pg-trip-writer` loadgen are left exactly as-is. Profiling/removing the local Postgres (so Postgres only exists in module 03) is a larger, separate change and will be its own PR.

## Verification

- `docker compose -f docker-compose.workshop.yml config` passes; services now report `backend`, `frontend`, `postgres`, `pg-trip-writer` (no `pgadmin`).
- `bash -n preflight.sh` passes.
- Repo-wide grep for `pgadmin` / `5050` / `--profile tools` across tracked docs/config returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)