### PR TITLE
workshop: remove local postgres; gate the loadgen behind a cdc profile

### DIFF
--- a/workshops/build_workshop/app/.env.workshop.example
+++ b/workshops/build_workshop/app/.env.workshop.example
@@ -43,9 +43,13 @@ PGSSLMODE=require
 # instance. Keep as-is unless a hand-out slip tells you otherwise.
 PG_PUBLICATION=pub_taxi
 #
-# LOCAL CONTAINER FALLBACK (offline dev, no managed instance): use the bundled
-# `postgres` service instead - set PGHOST=postgres, PGDATABASE=taxi, PGUSER=taxi,
-# PGPASSWORD=taxi, PGSSLMODE=prefer (matches the container credentials below).
+# The loadgen (pg-trip-writer) is gated behind the `cdc` compose profile, so it
+# does NOT run before module 03. In module 03, after filling the PG* values
+# above, uncomment COMPOSE_PROFILES=cdc below to switch it on. Every workshop
+# command uses --env-file .env.workshop, so from then on the loadgen starts (and
+# survives a down/up) automatically.
+# COMPOSE_PROFILES=cdc
+#
 # INSTRUCTOR-SHARED FALLBACK (only if managed Postgres is unavailable in your
 # org): fill all PG* values from the hand-out slip your instructor provides.
 
@@ -54,13 +58,6 @@ PG_PUBLICATION=pub_taxi
 # instance). Effective rows/sec ~= RATE_PER_SEC.
 RATE_PER_SEC=2
 BATCH_SIZE=10
-
-# === Local fallback Postgres container credentials =========================
-# Only used by the bundled `postgres` service (when PGHOST=postgres). Keep in
-# sync with the PG* values above if you rely on the local container fallback.
-POSTGRES_DB=taxi
-POSTGRES_USER=taxi
-POSTGRES_PASSWORD=taxi
 
 # === AI chat + Langfuse (Module 07) ========================================
 # Your own OpenAI API key powers the in-app chat (NL-to-SQL). The app runs
@@ -117,7 +114,6 @@ CREDS_IV=e2341419ec3dd3d19b13a1a87fafcbfb
 # === Host port mappings (change only on conflicts) =========================
 BACKEND_HOST_PORT=8000
 FRONTEND_HOST_PORT=8080
-POSTGRES_HOST_PORT=5432
 
 # === Backend query safety limits (rarely changed) ==========================
 API_CORS_ORIGINS=http://localhost:5173,http://localhost:8080

--- a/workshops/build_workshop/app/README.md
+++ b/workshops/build_workshop/app/README.md
@@ -2,9 +2,9 @@
 
 The NYC-taxi analytics app participants run locally during the ClickHouse BUILD
 Workshop: a React ops dashboard (with an AI chat panel), a FastAPI analytics backend,
-a local Postgres with a synthetic trip generator, and an optional ClickStack
-OpenTelemetry overlay. ClickHouse itself is your own ClickHouse Cloud service; live
-ingestion is Postgres CDC via ClickPipes.
+a synthetic trip generator that streams into your ClickHouse-managed Postgres (from
+module 03), and an optional ClickStack OpenTelemetry overlay. ClickHouse itself is your
+own ClickHouse Cloud service; live ingestion is Postgres CDC via ClickPipes.
 
 Follow the playbook (`../playbook`, published at demohouse.cloud/workshop) from
 module 00 — it walks through every step below in order.
@@ -29,7 +29,6 @@ Host ports (override any of these in `.env.workshop` if it is already taken —
 |---|---|---|
 | Frontend (UI) | 8080 | `FRONTEND_HOST_PORT` |
 | Backend API | 8000 | `BACKEND_HOST_PORT` |
-| Postgres (local fallback) | 5432 | `POSTGRES_HOST_PORT` |
 | OTel gRPC (otel overlay) | 4317 | `OTEL_GRPC_HOST_PORT` |
 | OTel HTTP (otel overlay) | 4318 | `OTEL_HTTP_HOST_PORT` |
 

--- a/workshops/build_workshop/app/WORKSHOP_CHANGES.md
+++ b/workshops/build_workshop/app/WORKSHOP_CHANGES.md
@@ -46,10 +46,10 @@ upstream demo's compose)
 
 Contains only:
 
-- `postgres` -- local fallback only (kept `wal_level=logical` for parity);
 - `backend` -- all ClickHouse params env-driven, defaulting to `8443` + TLS;
 - `frontend` -- unchanged build, nginx still proxies `/api` to `backend:8000`;
-- `pg-trip-writer` -- the loadgen, PG connection env-driven, throttled.
+- `pg-trip-writer` -- the loadgen, PG connection env-driven, throttled; gated
+  behind the `cdc` profile so it only runs from module 03 (no local `postgres`).
 
 Deliberately **omitted**: `clickhouse`, `ch-ui`, `broker`, `connect`,
 `kafka-ui`, `pg-cdc-init`, `clickhouse-cdc-init`, `connect-init`. ClickHouse is
@@ -62,17 +62,20 @@ with the local stack.
 
 ### 3. Loadgen (pg-trip-writer)
 
-`loadgen/pg_trip_writer.py` -- **no code change needed**. It was already fully
-env-driven for the Postgres connection (`PGHOST`, `PGPORT`, `PGDATABASE`,
-`PGUSER`, `PGPASSWORD`) and already had a configurable write rate
-(`RATE_PER_SEC`, `BATCH_SIZE`, effective delay = `BATCH_SIZE / RATE_PER_SEC`).
+`loadgen/pg_trip_writer.py` is fully env-driven for the Postgres connection
+(`PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`) with a configurable
+write rate (`RATE_PER_SEC`, `BATCH_SIZE`, effective delay = `BATCH_SIZE /
+RATE_PER_SEC`). It now exits with a clear message if `PGHOST` is unset rather
+than defaulting to a (removed) local host.
 
 The workshop compose lowers the defaults to `RATE_PER_SEC=2`, `BATCH_SIZE=10`
 (from `10`/`25` in local) because a single shared managed Postgres may be fed by
 30+ concurrent generators. Participants can raise or lower this via env, or drop
 the generator entirely with `docker compose ... up -d --scale pg-trip-writer=0`.
 
-The compose also passes `PGSSLMODE` (default `prefer`) through to the loadgen.
+The service is gated behind the `cdc` compose profile and connects with
+`PGSSLMODE=require` (managed Postgres mandates TLS); it starts once
+`COMPOSE_PROFILES=cdc` and the PG* values are set in module 03.
 psycopg3/libpq honors it natively, so no code change is needed; set
 `PGSSLMODE=require` for the shared managed Postgres, which mandates TLS.
 
@@ -164,6 +167,9 @@ Each is now addressed so any participant can get to a running app:
   Apple Silicon, no warning). The postgis init is kept but made non-fatal (a
   `DO`/`EXCEPTION` block) so it is portable across a plain and a PostGIS image and
   never aborts container init.
+  **Update:** the local-fallback `postgres` service was later removed entirely;
+  the loadgen writes only to your managed Postgres from module 03 and is gated
+  behind the `cdc` profile, so this image note is historical.
 
 - **Requirements documented** (`README.md`): a Requirements section (Docker engine
   with 6 GB + Compose v2, ~10 GB disk, macOS/Linux/WSL2 stance, and a host-port
@@ -218,7 +224,8 @@ plain HTTP (secure inferred `false` from the port).
 
 - `docker compose -f docker-compose.workshop.yml config` passes with **exit 0
   and no warnings** with no `.env` file, and again with a filled `--env-file`.
-  Only `backend`, `frontend`, `postgres`, and `pg-trip-writer` are present.
+  Only `backend` and `frontend` are present by default; `pg-trip-writer` appears
+  with the `cdc` profile (the local `postgres` service was removed).
   Env interpolation was confirmed (e.g. `CLICKHOUSE_SECURE: "true"`, filled
   `CLICKHOUSE_HOST`, `PGHOST`, `RATE_PER_SEC`, and `PGSSLMODE` defaulting to
   `prefer` and overriding to `require`).

--- a/workshops/build_workshop/app/docker-compose.workshop.yml
+++ b/workshops/build_workshop/app/docker-compose.workshop.yml
@@ -5,10 +5,11 @@
 #     own ClickHouse Cloud service (https:8443) via CLICKHOUSE_* env vars.
 #   - No `ch-ui` (use the ClickHouse Cloud SQL console instead).
 #   - No `broker` / `connect` / `kafka-ui` / *-cdc-init. Change data capture is
-#     handled Cloud-side by ClickPipes reading from the shared managed Postgres.
-#   - `postgres` remains only as a LOCAL FALLBACK for running the loadgen offline.
-#     In the workshop the loadgen and app point at a shared managed Postgres via
-#     the PG* env vars (see .env.workshop.example).
+#     handled Cloud-side by ClickPipes reading from your managed Postgres.
+#   - No local `postgres`. The loadgen (`pg-trip-writer`) writes to your own
+#     Postgres managed by ClickHouse (created in module 03) and is gated behind
+#     the `cdc` profile, so nothing Postgres-related starts before module 03.
+#     Set PG* for that managed instance in .env.workshop (see the example).
 #
 # Usage:
 #   cp .env.workshop.example .env.workshop
@@ -18,45 +19,6 @@
 # This file is self-contained: it does NOT extend docker-compose.yml.
 
 services:
-  # Local fallback Postgres. Only used when PGHOST points here (the default).
-  # For the workshop, set PGHOST/PGPORT/... to the shared managed Postgres and
-  # this container is simply idle. wal_level=logical is kept so it can also act
-  # as a ClickPipes/CDC source during local experimentation.
-  postgres:
-    # Official multi-arch image (linux/amd64 + linux/arm64): runs natively on
-    # Apple Silicon, so no "platform mismatch" warning or slow emulation. The
-    # workshop path needs no geo types, so PostGIS is not required; the postgis
-    # init (db/postgres/init/000_postgis.sql) is written to be non-fatal here.
-    image: postgres:16
-    container_name: nyc-taxi-workshop-postgres
-    hostname: postgres
-    environment:
-      - POSTGRES_DB=${POSTGRES_DB:-taxi}
-      - POSTGRES_USER=${POSTGRES_USER:-taxi}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-taxi}
-    command:
-      - "postgres"
-      - "-c"
-      - "wal_level=logical"
-      - "-c"
-      - "max_replication_slots=10"
-      - "-c"
-      - "max_wal_senders=10"
-    ports:
-      - "${POSTGRES_HOST_PORT:-5432}:5432"
-    volumes:
-      - ./db/postgres/init:/docker-entrypoint-initdb.d:ro
-      - ./db/sample:/sample:ro
-      - postgres_data:/var/lib/postgresql/data
-    # pg_isready ships in the postgres image. $$ keeps the var for the container
-    # shell to expand (compose would otherwise interpolate it at config time).
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
-
   backend:
     build:
       context: ./backend
@@ -121,32 +83,30 @@ services:
       retries: 5
       start_period: 10s
 
-  # Writes synthetic trips into Postgres; ClickPipes captures them Cloud-side.
-  # Defaults to the local `postgres` service. Point PG* at the shared managed
-  # Postgres for the workshop. RATE_PER_SEC is intentionally low because a
-  # shared Postgres may be fed by 30+ concurrent generators.
+  # Writes synthetic trips into your managed Postgres; a ClickPipe captures them
+  # Cloud-side. Gated behind the `cdc` profile so it does NOT start with a bare
+  # `docker compose up -d` (modules 00-02). Module 03 starts it once PG* point at
+  # your managed instance, e.g.:
+  #   docker compose --env-file .env.workshop -f docker-compose.workshop.yml \
+  #     --profile cdc up -d pg-trip-writer
+  # RATE_PER_SEC is intentionally low (a shared instance may see many generators).
   pg-trip-writer:
     build:
       context: ./loadgen
     container_name: nyc-taxi-workshop-pg-trip-writer
-    depends_on:
-      - postgres
+    profiles: ["cdc"]
     environment:
-      - PGHOST=${PGHOST:-postgres}
+      # No local default: set these to your managed Postgres (module 03).
+      - PGHOST=${PGHOST:-}
       - PGPORT=${PGPORT:-5432}
-      - PGDATABASE=${PGDATABASE:-taxi}
-      - PGUSER=${PGUSER:-taxi}
-      - PGPASSWORD=${PGPASSWORD:-taxi}
-      # psycopg3/libpq reads PGSSLMODE natively. 'prefer' works for the local
-      # fallback (falls back to plaintext); set 'require' for the shared managed
-      # Postgres, which mandates TLS.
-      - PGSSLMODE=${PGSSLMODE:-prefer}
+      - PGDATABASE=${PGDATABASE:-postgres}
+      - PGUSER=${PGUSER:-postgres}
+      - PGPASSWORD=${PGPASSWORD:-}
+      # Managed Postgres mandates TLS; psycopg3/libpq reads PGSSLMODE natively.
+      - PGSSLMODE=${PGSSLMODE:-require}
       # Publication the CDC ClickPipe subscribes to. The loadgen creates it on
-      # your own managed Postgres; on the shared fallback it is pre-created.
+      # your own managed Postgres; on the instructor shared fallback it is pre-created.
       - PG_PUBLICATION=${PG_PUBLICATION:-pub_taxi}
       - RATE_PER_SEC=${RATE_PER_SEC:-2}
       - BATCH_SIZE=${BATCH_SIZE:-10}
     restart: unless-stopped
-
-volumes:
-  postgres_data:

--- a/workshops/build_workshop/app/loadgen/pg_trip_writer.py
+++ b/workshops/build_workshop/app/loadgen/pg_trip_writer.py
@@ -24,11 +24,11 @@ def env(name: str, default: str) -> str:
     return default if v is None or v == "" else v
 
 
-PGHOST = env("PGHOST", "postgres")
+PGHOST = env("PGHOST", "")
 PGPORT = int(env("PGPORT", "5432"))
-PGDATABASE = env("PGDATABASE", "taxi")
-PGUSER = env("PGUSER", "taxi")
-PGPASSWORD = env("PGPASSWORD", "taxi")
+PGDATABASE = env("PGDATABASE", "postgres")
+PGUSER = env("PGUSER", "postgres")
+PGPASSWORD = env("PGPASSWORD", "")
 # Publication the CDC ClickPipe subscribes to. On the participant's own managed
 # Postgres the loadgen creates it (the connection user is the instance admin);
 # on the shared-fallback instance the instructor pre-creates it and the scoped
@@ -84,6 +84,13 @@ def pick_zone_id() -> int:
 
 
 def main() -> None:
+    if not PGHOST:
+        logger.error(
+            "[loadgen] PGHOST is not set. Point PG* at your managed Postgres "
+            "(module 03) before starting pg-trip-writer."
+        )
+        raise SystemExit(1)
+
     dsn = f"host={PGHOST} port={PGPORT} dbname={PGDATABASE} user={PGUSER} password={PGPASSWORD}"
     logger.info(f"[loadgen] connecting: {PGHOST}:{PGPORT} db={PGDATABASE} user={PGUSER}")
 

--- a/workshops/build_workshop/app/preflight.sh
+++ b/workshops/build_workshop/app/preflight.sh
@@ -10,7 +10,7 @@
 # the stack actually tripped over: the Docker CLI + daemon, that the daemon can
 # really start a container (catches a wedged engine), host-port collisions on the
 # EFFECTIVE ports from .env.workshop, the required .env.workshop values, and
-# network reachability of ClickHouse Cloud (and the shared Postgres, if used).
+# network reachability of ClickHouse Cloud (and your managed Postgres, once set).
 #
 # Every failure prints a one-line fix hint. The script exits non-zero if any check
 # FAILs (warnings do not affect the exit code), so it composes into scripts and CI.
@@ -361,7 +361,7 @@ HAVE_ENV=0
 CH_HOST=""
 CH_PORT="8443"
 CH_PW=""
-PGHOST_VAL="postgres"
+PGHOST_VAL=""
 
 if [ "$HAVE_ENV" -eq 1 ]; then
   pass ".env.workshop found"
@@ -398,17 +398,17 @@ if [ "$HAVE_ENV" -eq 1 ]; then
          "add LANGFUSE_PUBLIC_KEY/SECRET_KEY before module 07 if you want traces; chat works untraced without them"
   fi
 
-  PGHOST_VAL=$(env_get PGHOST); [ -n "$PGHOST_VAL" ] || PGHOST_VAL="postgres"
-  if [ "$PGHOST_VAL" = "postgres" ]; then
-    pass "PGHOST=postgres (using the local fallback Postgres container)"
+  PGHOST_VAL=$(env_get PGHOST)
+  if [ -n "$PGHOST_VAL" ]; then
+    pass "PGHOST=$PGHOST_VAL (managed Postgres for the live CDC path, module 03)"
   else
-    pass "PGHOST=$PGHOST_VAL (using a shared managed Postgres)"
+    pass "PGHOST not set yet (set it in module 03 for live CDC; not needed before then)"
   fi
 else
   fail ".env.workshop not found in $SCRIPT_DIR" \
        "run: cp .env.workshop.example .env.workshop  then fill in CLICKHOUSE_HOST and CLICKHOUSE_PASSWORD"
   if [ -f "$EXAMPLE_FILE" ]; then
-    warn "port checks below use the example defaults (8080/8000/5432/4317/4318)" \
+    warn "port checks below use the example defaults (8080/8000/4317/4318)" \
          "create .env.workshop so preflight checks your real, effective ports"
   fi
 fi
@@ -428,13 +428,11 @@ fi
 section "Host port availability (effective ports)"
 FRONTEND_PORT=$(resolve_port FRONTEND_HOST_PORT 8080)
 BACKEND_PORT=$(resolve_port BACKEND_HOST_PORT 8000)
-POSTGRES_PORT=$(resolve_port POSTGRES_HOST_PORT 5432)
 OTEL_GRPC_PORT=$(resolve_port OTEL_GRPC_HOST_PORT 4317)
 OTEL_HTTP_PORT=$(resolve_port OTEL_HTTP_HOST_PORT 4318)
 
 check_port FRONTEND_HOST_PORT "$FRONTEND_PORT" core ""
 check_port BACKEND_HOST_PORT "$BACKEND_PORT" core ""
-check_port POSTGRES_HOST_PORT "$POSTGRES_PORT" core ""
 check_port OTEL_GRPC_HOST_PORT "$OTEL_GRPC_PORT" optional " (only with the otel overlay)"
 check_port OTEL_HTTP_HOST_PORT "$OTEL_HTTP_PORT" optional " (only with the otel overlay)"
 
@@ -465,18 +463,18 @@ else
        "set CLICKHOUSE_HOST in .env.workshop first"
 fi
 
-if [ "$PGHOST_VAL" != "postgres" ] && [ -n "$PGHOST_VAL" ]; then
+if [ -n "$PGHOST_VAL" ]; then
   PGPORT_VAL=$(env_get PGPORT); [ -n "$PGPORT_VAL" ] || PGPORT_VAL="5432"
   if tcp_reachable "$PGHOST_VAL" "$PGPORT_VAL" 8; then
-    pass "shared Postgres reachable ($PGHOST_VAL:$PGPORT_VAL, TCP)"
+    pass "managed Postgres reachable ($PGHOST_VAL:$PGPORT_VAL, TCP)"
   else
-    # WARN, not FAIL: the app dashboards run without the loadgen; the shared
-    # Postgres only feeds the live CDC path (module 03).
-    warn "shared Postgres not reachable at $PGHOST_VAL:$PGPORT_VAL (only needed for the live CDC path, module 03)" \
-         "check wifi / VPN / firewall and that the shared Postgres endpoint and its IP allowlist are correct"
+    # WARN, not FAIL: only the live CDC path (module 03) needs Postgres; the app
+    # dashboards run without the loadgen.
+    warn "managed Postgres not reachable at $PGHOST_VAL:$PGPORT_VAL (only needed for the live CDC path, module 03)" \
+         "check wifi / VPN / firewall and that the managed Postgres endpoint and its IP allowlist are correct"
   fi
 else
-  pass "using the local fallback Postgres (no external Postgres reachability check needed)"
+  pass "no PGHOST set (managed Postgres is created in module 03; nothing to check yet)"
 fi
 
 # --- Summary ---------------------------------------------------------------

--- a/workshops/build_workshop/playbook/content/docs/instructor/03-realtime-cdc.mdx
+++ b/workshops/build_workshop/playbook/content/docs/instructor/03-realtime-cdc.mdx
@@ -39,8 +39,9 @@ begin streaming; account for it.
   `require` (managed Postgres mandates TLS).
 - **Region mismatch.** Cross-region Postgres-to-ClickHouse works but adds latency; steer
   participants to create the Postgres in the same region as their ClickHouse service.
-- **Data generator not started**, so nothing appears to move — check `pg-trip-writer` is
-  up and its log shows `inserted N trips`.
+- **Data generator not started**, so nothing appears to move — the loadgen is behind the
+  `cdc` profile, so confirm `COMPOSE_PROFILES=cdc` is in `.env.workshop`, then check
+  `pg-trip-writer` is up and its log shows `inserted N trips`.
 - **Pipe create fails with `BAD_REQUEST: table realtime_trips exists and is not empty`.**
   Only on a **re-run/reset**, not a fresh participant: deleting a ClickPipe drops the
   source replication slot but leaves its destination table behind, and the CLI refuses to
@@ -61,7 +62,7 @@ rather than creating one — that is expected, not an error.
 ## Reset steps
 
 - Delete and recreate the ClickPipe from the console.
-- Restart the data generator:
+- Restart the data generator (needs `COMPOSE_PROFILES=cdc` in `.env.workshop`):
   `docker compose --env-file .env.workshop -f docker-compose.workshop.yml up -d pg-trip-writer`
   (turn it off with `--scale pg-trip-writer=0`).
 - Reset a lost Postgres password with `clickhousectl cloud postgres reset-password`.

--- a/workshops/build_workshop/playbook/content/docs/learner/03-realtime-cdc.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/03-realtime-cdc.mdx
@@ -85,8 +85,11 @@ Copy both somewhere safe right now.
   finish first.
 </Callout>
 
-The workshop stack already includes `pg-trip-writer`, the data generator. Put your
-instance's values into `.env.workshop` (in the `app` directory):
+The workshop stack ships `pg-trip-writer`, the data generator, gated behind the `cdc`
+compose profile so it stays off until now. Put your instance's values into
+`.env.workshop` (in the `app` directory), including `COMPOSE_PROFILES=cdc` — every later
+`docker compose` command uses `--env-file .env.workshop`, so that one line switches the
+generator on from here on (and it comes back after a `down`/`up`):
 
 ```bash
 PGHOST=<hostname from the create output>
@@ -96,9 +99,10 @@ PGUSER=postgres
 PGPASSWORD=<one-time password from the create output>
 PGSSLMODE=require
 PG_PUBLICATION=pub_taxi
+COMPOSE_PROFILES=cdc
 ```
 
-Then restart just the generator and watch its log:
+Then start the generator and watch its log:
 
 ```bash
 docker compose --env-file .env.workshop -f docker-compose.workshop.yml up -d pg-trip-writer

--- a/workshops/build_workshop/playbook/content/docs/learner/troubleshooting.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/troubleshooting.mdx
@@ -23,12 +23,12 @@ has a ready-to-paste prompt that turns it into your instructor.
 ### "port is already allocated" on up
 
 - **Symptom** - `docker compose ... up` fails with `Bind for 0.0.0.0:8080 failed: port is
-  already allocated` (or `:8000`, `:5432`).
+  already allocated` (or `:8000`).
 - **Why** - another process, or an old workshop container, already holds that host port.
 - **Fix** - run `./preflight.sh`. It names what is holding the port and prints the exact
   override to set, following the base-port + 20000 convention, for example
   `set FRONTEND_HOST_PORT=28080 in .env.workshop`. The override vars are
-  `FRONTEND_HOST_PORT`, `BACKEND_HOST_PORT`, `POSTGRES_HOST_PORT`, and for the observability
+  `FRONTEND_HOST_PORT`, `BACKEND_HOST_PORT`, and for the observability
   overlay `OTEL_GRPC_HOST_PORT` / `OTEL_HTTP_HOST_PORT`. Set the suggested value, re-run
   preflight, then start the stack. Only the host ports move; the in-container ports are
   unchanged, so this is safe.


### PR DESCRIPTION
## What

Makes Postgres exist **only in module 03**: removes the local fallback `postgres` container and puts the loadgen (`pg-trip-writer`) behind a `cdc` compose profile.

> **Stacked on #24** (remove pgadmin) — both touch the same files. Base is `chore/remove-pgadmin`; GitHub will retarget this to `build-workshop-v1` once #24 merges. Review/merge #24 first.

## Why

The local `postgres` container was a vestige of the pre-Cloud design: it started with the module-00 stack, the loadgen wrote synthetic trips into it that **nothing consumed** (CDC reads the *managed* Postgres created in module 03), and its host port 5432 was a preflight **core** check for a service the workshop never used. This is the cleanup we scoped out of #24.

## Changes

- **`docker-compose.workshop.yml`** — remove the `postgres` service + `postgres_data` volume; add `profiles: ["cdc"]` to `pg-trip-writer`, drop its `depends_on: postgres`, and switch PG* defaults from the local container (`taxi`/`prefer`) to the managed instance (`postgres`/`require`).
- **`loadgen/pg_trip_writer.py`** — default `PGHOST` to `""` and **exit with a clear message** if unset, instead of silently defaulting to the removed host.
- **`preflight.sh`** — drop the core port-5432 check; reframe the PGHOST checks around the managed instance (unset before module 03 is a PASS, not a FAIL).
- **`.env.workshop.example`** — drop the local-container creds and `POSTGRES_HOST_PORT`; add a commented `COMPOSE_PROFILES=cdc` with guidance.
- **docs** — module 03 (learner + instructor) sets `COMPOSE_PROFILES=cdc`; README, troubleshooting, and `WORKSHOP_CHANGES.md` updated.

## How the loadgen is summoned (the key design choice)

`COMPOSE_PROFILES=cdc` added to `.env.workshop` in module 03 activates the profile for **every** `--env-file .env.workshop` command. So the loadgen:
- **stays off** in modules 00–02 (no line yet → bare `up -d` = `backend` + `frontend` only),
- **turns on** from module 03, and **stays on** through the otel-overlay modules (05/06b/08) and after any `down`/`up` — with **no per-command `--profile` flag** to remember.

Confirmed the otel overlay only overlays `backend`/`frontend` (adds collectors); it does not modify `pg-trip-writer`, and non-instrumented services are scraped by the optional `container-logs` collector, so an already-running loadgen just needs to be up — those modules don't need to re-summon it.

## Verification

- `docker compose config --services`: bare → `backend frontend`; `--profile cdc` → adds `pg-trip-writer`; **`COMPOSE_PROFILES=cdc` via `--env-file`** → adds it (tested — this is what the docs rely on).
- `workshop` and `workshop + otel` configs validate.
- **Live:** built + started the loadgen under `--profile cdc` with no `PGHOST` → it starts (profile works) and **fails fast** with `PGHOST is not set…` then restarts, instead of silently connecting anywhere. Torn down after.
- `bash -n preflight.sh` and `py_compile pg_trip_writer.py` pass.
- Swept for orphaned local-postgres refs: only remaining `depends_on` are `frontend→backend`, `backend→otel-collector`, and LibreChat→its own `mongodb` (module 06b unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)