### PR TITLE
playbook: unwrap example prompts onto single lines

### DIFF
--- a/workshops/build_workshop/playbook/content/docs/learner/02-base-app.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/02-base-app.mdx
@@ -61,8 +61,7 @@ React front end  ->  FastAPI back end  ->  ClickHouse Cloud (connected + seeded 
 Ask your coding agent to summarize the analytics endpoints:
 
 ```text
-Read the FastAPI backend and list each analytics endpoint, what it returns, and which
-table it reads from.
+Read the FastAPI backend and list each analytics endpoint, what it returns, and which table it reads from.
 ```
 
 ## How to verify you are done

--- a/workshops/build_workshop/playbook/content/docs/learner/04-clickhouse-agents.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/04-clickhouse-agents.mdx
@@ -49,8 +49,7 @@ chatting. The agent introspects your schema so its SQL is grounded.
 Ask progressively harder questions and read the SQL it generates. For example:
 
 ```text
-Which pickup zones had the highest average fare last week, and how did that change
-versus the prior week?
+Which pickup zones had the highest average fare last week, and how did that change versus the prior week?
 ```
 
 Then ask your own question about the ride-hailing business — this is your open step.

--- a/workshops/build_workshop/playbook/content/docs/learner/06-ai-sre.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/06-ai-sre.mdx
@@ -112,8 +112,7 @@ Confirm the connection works by asking the agent how the service is doing — a 
 check exercises the `clickstack_*` tools end to end:
 
 ```text
-Using the clickstack MCP, check the health of the nyc-taxi-backend service over the last
-24h — request volume, error rate, and latency — and tell me if anything looks off.
+Using the clickstack MCP, check the health of the nyc-taxi-backend service over the last 24h — request volume, error rate, and latency — and tell me if anything looks off.
 ```
 
 ![Coding agent calling the ClickStack MCP tools to assess nyc-taxi-backend health, reporting total spans, error rate, p95 and max latency, and last activity in a summary table](/screenshots/06-agent-health-check.png)
@@ -129,8 +128,7 @@ the generator inspects your telemetry first and builds tiles from what it actual
 tiles):
 
 ```text
-explore the app's traces and logs, then build and save an SRE dashboard showing request
-rate, error rate, and p95 latency per service
+explore the app's traces and logs, then build and save an SRE dashboard showing request rate, error rate, and p95 latency per service
 ```
 
 ![HyperDX Dashboards page with the "Generate dashboard with AI" modal open and the SRE dashboard prompt typed in](/screenshots/06-generate-dashboard-prompt.png)

--- a/workshops/build_workshop/playbook/content/docs/learner/08-break-and-fix.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/08-break-and-fix.mdx
@@ -55,9 +55,7 @@ surface in the dashboards and in ClickStack.
 Point your agent at the ClickStack MCP and describe the symptom, not the cause:
 
 ```text
-Something is wrong with the app: users are seeing errors. Using the clickstack MCP,
-investigate the traces and logs, localize the failure, and tell me the root cause with
-the evidence.
+Something is wrong with the app: users are seeing errors. Using the clickstack MCP, investigate the traces and logs, localize the failure, and tell me the root cause with the evidence.
 ```
 
 

--- a/workshops/build_workshop/playbook/content/docs/learner/self-paced.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/self-paced.mdx
@@ -45,13 +45,7 @@ your coding agent in module 00. That same agent makes a capable workshop instruc
 the block below into it, filling in the module number and what you are seeing:
 
 ```text
-You are my workshop instructor. The workshop lives in this repo under
-workshops/build_workshop: the playbook markdown is in playbook/content/docs
-(learner and instructor tracks), the app is in app/, and infrastructure notes
-are in infra/README.md. I am on module NN and stuck: <describe what you see>.
-Read the relevant module page and the troubleshooting page, inspect my local
-state (docker compose ps, container logs, and .env.workshop WITHOUT printing
-any secret values), and walk me to the module's verify step.
+You are my workshop instructor. The workshop lives in this repo under workshops/build_workshop: the playbook markdown is in playbook/content/docs (learner and instructor tracks), the app is in app/, and infrastructure notes are in infra/README.md. I am on module NN and stuck: <describe what you see>. Read the relevant module page and the troubleshooting page, inspect my local state (docker compose ps, container logs, and .env.workshop WITHOUT printing any secret values), and walk me to the module's verify step.
 ```
 
 Because it has the skills and the MCP from module 00, the agent can also query your Cloud


### PR DESCRIPTION
## What

Joins each wrapped example **prompt** onto a single line. The prompts live in ` ```text ` fences, where the source hard-wrap at ~90 chars renders as a literal mid-sentence line break — awkward to read and to copy-paste. [Reported example](https://dev.demohouse.cloud/workshop/docs/learner/04-clickhouse-agents#step-3--explore-conversationally).

Before (module 04):
```
Which pickup zones had the highest average fare last week, and how did that change
versus the prior week?
```
After:
```
Which pickup zones had the highest average fare last week, and how did that change versus the prior week?
```

## Prompts unwrapped (6 across 5 files)

- `02-base-app` — "Read the FastAPI backend and list each analytics endpoint…"
- `04-clickhouse-agents` — "Which pickup zones had the highest average fare…" (the reported one)
- `06-ai-sre` — the MCP health-check prompt **and** the generate-dashboard prompt
- `08-break-and-fix` — "Something is wrong with the app… investigate…"
- `self-paced` — the instructor-prompt template

## Deliberately left alone (not prompts)

I extracted every fenced block programmatically and only touched natural-language prompts. These multi-line blocks are **not** prompts and keep their line breaks:
- `index.mdx` — the repo directory tree
- `09-wrap-up` — the three take-home bullet points
- `02-base-app` — the `React → FastAPI → ClickHouse` data-flow diagram
- `06b` — its prompt was already a single line

Independent of #23/#24/#25 (different files), so it targets `build-workshop-v1` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)