### PR TITLE
playbook(05-clickstack): drop the 'what diverges from the classic setup' callout

### DIFF
--- a/workshops/build_workshop/playbook/content/docs/learner/05-clickstack.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/05-clickstack.mdx
@@ -39,25 +39,6 @@ That single-signs you on into HyperDX.
 
 *HyperDX rendering the app's traces: the `nyc-taxi-backend` service with its `/api/...` request spans.*
 
-
-<Callout title="Managed ClickStack: what diverges from the classic setup">
-  - The back end uses vanilla OpenTelemetry, not the convenience
-    `hyperdx-opentelemetry` package the ClickStack docs suggest. That package hard-pins
-    `opentelemetry-api==1.30.0`, which conflicts with the Langfuse v4 SDK the chat
-    feature uses (needs `opentelemetry-api>=1.33.1`) — the two cannot share one
-    environment. The ClickStack collector ingests standard OTLP, so the vanilla distro
-    behaves identically; the workshop just sets the exporter env vars itself.
-  - ClickStack's telemetry lives in a separate database on your service
-    (`CLICKSTACK_DATABASE=otel`), distinct from the app's data database
-    (`CLICKHOUSE_DATABASE=nyc_tlc_data`).
-  - Traces always flow over OTLP from the auto-instrumented back end and are the signal
-    you rely on here. Application logs did not deliver reliably over OTLP in testing, so
-    read them with `docker compose ... logs` (or enable the optional
-    `--profile container-logs` collector, which scrapes raw container stdout — a
-    Linux-host path; on Docker Desktop the daemon runs in a VM and that host mount may
-    not be available).
-</Callout>
-
 ## Step 2 — Run the OpenTelemetry collector overlay
 
 <Callout title="Check the collector ports first">


### PR DESCRIPTION
## What

Removes the entire **"Managed ClickStack: what diverges from the classic setup"** callout from module 05, per [feedback](https://dev.demohouse.cloud/workshop/docs/learner/05-clickstack) that its three points aren't relevant to a learner.

## Why

All three bullets were internal build detail, not learner guidance:
1. Vanilla OpenTelemetry vs the `hyperdx-opentelemetry` convenience package (a dependency-conflict rationale) — build trivia.
2. ClickStack's `otel` database being separate from the app's `nyc_tlc_data` — already implied by the `CLICKSTACK_DATABASE` var in Step 2.
3. The traces-vs-logs caveat (see note below).

## Change

One file, 19 deletions — just the callout; surrounding spacing left clean.

## Follow-up worth flagging (not in this PR)

The removed 3rd bullet claimed *"application logs did not deliver reliably over OTLP in testing."* That's stale: the backend **is** configured to ship app logs over OTLP (`OTEL_LOGS_EXPORTER=otlp` + `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true`), and `observability.py` was fixed (`6b99c42`) to preserve the OTLP log handler so `otel_logs` actually fills. Three other spots still repeat the stale "logs aren't in HyperDX / use `docker compose logs`" framing — the **Goal**, **Step 3**, and **Wrap-up** paragraphs. Those are out of scope here; can be corrected in a separate PR once the live OTLP-logs behaviour is confirmed against Managed ClickStack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)