### PR TITLE
playbook(04-clickhouse-agents): add ClickHouse tool step to agent creation

### DIFF
--- a/workshops/build_workshop/playbook/content/docs/learner/04-clickhouse-agents.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/04-clickhouse-agents.mdx
@@ -41,8 +41,13 @@ Two entry points, both using your existing ClickHouse Cloud identity:
 ## Step 2 — Create an agent over your taxi data
 
 Click **Create New Agent**, give it a **Name**, **Instructions** (for example: answer
-questions about the NYC taxi data in `nyc_tlc_data`), and pick a **Model**, then start
-chatting. The agent introspects your schema so its SQL is grounded.
+questions about the NYC taxi data in `nyc_tlc_data`), and pick a **Model**.
+
+Add a tool called **ClickHouse** and confirm it shows as **Connected** — this is what
+lets the agent introspect your schema and run SQL against your service. Without a
+connected ClickHouse tool the agent has nothing to query.
+
+Then start chatting. The agent introspects your schema so its SQL is grounded.
 
 ## Step 3 — Explore conversationally
 


### PR DESCRIPTION
## What

Adds an explicit step to **Step 2 — Create an agent over your taxi data** (learner module 04) telling learners to add a **ClickHouse** tool and confirm it shows as **Connected** before they start chatting.

## Why

Without a connected ClickHouse tool the agent has no data source to introspect or query — this is called out as a common failure in the instructor notes. Making the tool + connection step explicit prevents learners from getting stuck.

## Scope

- Single file: `playbook/content/docs/learner/04-clickhouse-agents.mdx`
- Docs-only; no code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)