### PR TITLE
fix(backend): compare/period 500 when a zone filter is applied

### DIFF
--- a/workshops/build_workshop/app/backend/app/query_builders.py
+++ b/workshops/build_workshop/app/backend/app/query_builders.py
@@ -299,10 +299,10 @@ def compare_period_sql(
         shared_clauses.append("payment_type = {payment_type:UInt8}")
         params["payment_type"] = int(payment_type)
     if pickup_zone_id:
-        shared_clauses.append("pickup_zone_id IN {pickup_zone_ids:Array(UInt16)}")
+        shared_clauses.append("pickup_location_id IN {pickup_zone_ids:Array(UInt16)}")
         params["pickup_zone_ids"] = [int(x) for x in pickup_zone_id]
     if dropoff_zone_id:
-        shared_clauses.append("dropoff_zone_id IN {dropoff_zone_ids:Array(UInt16)}")
+        shared_clauses.append("dropoff_location_id IN {dropoff_zone_ids:Array(UInt16)}")
         params["dropoff_zone_ids"] = [int(x) for x in dropoff_zone_id]
     shared_sql = (" AND " + " AND ".join(shared_clauses)) if shared_clauses else ""
 

--- a/workshops/build_workshop/app/backend/tests/test_endpoints.py
+++ b/workshops/build_workshop/app/backend/tests/test_endpoints.py
@@ -121,6 +121,29 @@ def test_compare_period_delta_pct_null_when_b_zero(api_base_url: str, http: http
     assert all(x["delta_pct"] is None for x in rows)
 
 
+def test_compare_period_with_zone_filter(api_base_url: str, http: httpx.Client, sample_window: tuple[str, str]) -> None:
+    # Regression: a pickup/dropoff zone filter must be applied against the real
+    # taxi_trips columns (pickup_location_id / dropoff_location_id), not the
+    # output aliases pickup_zone_id / dropoff_zone_id, which do not exist in the
+    # CTE scope and used to raise ClickHouse UNKNOWN_IDENTIFIER (code 47).
+    start, end = sample_window
+    for filter_key in ("pickup_zone_id", "dropoff_zone_id"):
+        r = http.get(
+            f"{api_base_url}/api/compare/period",
+            params={
+                "a_start": start,
+                "a_end": end,
+                "b_start": start,
+                "b_end": end,
+                "group_by": "pickup_zone",
+                "metric": "trips",
+                "limit": 20,
+                filter_key: [161],
+            },
+        )
+        assert r.status_code == 200, f"{filter_key}: {r.text}"
+
+
 def test_anomalies_tip_ratio_with_threshold(api_base_url: str, http: httpx.Client, sample_window: tuple[str, str]) -> None:
     start, end = sample_window
     r = http.get(


### PR DESCRIPTION
## Problem

The dashboard's **Act 3 — Compare vs last Friday** returns `500 Internal Server Error` from `GET /api/compare/period` whenever a **pickup or dropoff zone filter** is active:

```
Code: 47. DB::Exception: Unknown expression or table expression identifier
`pickup_zone_id` in scope a. (UNKNOWN_IDENTIFIER)
```

## Root cause

`compare_period_sql` built its shared filter clauses using `pickup_zone_id` / `dropoff_zone_id` — but those are **output aliases**, not columns of `taxi_trips`. The clauses are injected into the `a` / `b` CTEs (`SELECT … FROM taxi_trips`), where those identifiers don't exist, so ClickHouse raised `UNKNOWN_IDENTIFIER` (code 47). Vendor/payment filters were unaffected because they used correct column names.

Every sibling builder (`_filters_sql`, `compare_pairs_sql`) already filters on the real columns `pickup_location_id` / `dropoff_location_id`; `compare_period_sql` was the outlier.

## Fix

Filter on `pickup_location_id` / `dropoff_location_id`, matching the other builders.

## Test

Adds `test_compare_period_with_zone_filter` (asserts `compare/period` returns 200 with a zone filter). It **fails before** the fix (500) and **passes after**.

## Verification

- New regression test: passes.
- Full endpoint suite: 11 passed, no regressions.
- Re-ran the exact failing request against a live service → HTTP 200 with correctly filtered zones.

Docs-only change from PR #29 is unrelated and not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)