### PR TITLE
playbook(07): make fault 01 the module's single incident

### DIFF
--- a/workshops/build_workshop/playbook/content/docs/instructor/07-break-and-fix.mdx
+++ b/workshops/build_workshop/playbook/content/docs/instructor/07-break-and-fix.mdx
@@ -9,30 +9,30 @@ Facilitator companion to the learner lesson
 ## Timing
 
 About 20 minutes. This is the incident lab; protect enough runway for the diagnosis to
-land before module 08 and the wrap-up. Rough per-fault diagnosis times: fault 02 = 5-10 min,
-fault 01 = 5-15 min, and fault 03 = 10-20 min only with the full roughly 30-million-row
-dataset. Run one fault per participant (or one for the room); with the default sample seed,
-use fault 02 then fault 01. Set a hard-stop at rehearsal so the wrap-up is not squeezed.
+land before module 08 and the wrap-up. The lab runs fault 01 (5-15 min diagnosis). Faults
+02 (5-10 min) and 03 (10-20 min, and only with the full roughly 30-million-row dataset)
+remain available as optional extra incidents for a fast room. Set a hard-stop at rehearsal
+so the wrap-up is not squeezed.
 
 ## Talk track
 
 - This is the payoff: use everything built so far to run a real incident.
-- If the room completed 06b, select fault 02 here so the LibreChat SRE agent applies its
-  telemetry-plus-source workflow to a new incident instead of repeating fault 01.
+- If the room completed 06b, fault 01 is already diagnosed — this module becomes
+  confirm-fix-verify, so keep the momentum and move quickly to the fix.
 - Describe the symptom, not the cause, and let the agents converge from telemetry.
 - Consider showing several attendees' diagnoses side by side on the projector.
-- Run one fault at a time. Teach fault 02 first and fault 01 second. Add fault 03 between
-  them only when the full dataset was pre-seeded; use the shared stash-and-switch reset
-  below between faults.
+- The lab runs fault 01. If time permits an extra round, add fault 02 (and fault 03 only
+  when the full dataset was pre-seeded); use the shared stash-and-switch reset below
+  between faults.
 
 ## Answer key
 
 Do not share this section with learners; it lives in the playbook only and is never
 committed to the app repo. Each fault is one small change on its own branch off `build-workshop-v1`;
-the fix is to revert it. Run one fault at a time. Recommended teaching order and rough
-diagnosis times: fault 02 first (5-10 min, warm-up, the trace tells all), fault 01 second
-(5-15 min, curveball — the backend is innocent), and fault 03 only when the full dataset
-is available (10-20 min, deeper ClickHouse reasoning).
+the fix is to revert it. Run one fault at a time. The lab's incident is fault 01 (5-15 min,
+curveball — the backend is innocent). Optional extras for a fast room: fault 02 (5-10 min,
+warm-up, the trace tells all) and fault 03 only when the full dataset is available
+(10-20 min, deeper ClickHouse reasoning).
 
 Shared reset for every fault (the stash preserves participant edits and avoids a blocked
 branch switch):
@@ -134,8 +134,8 @@ with the HTML document rather than a 404, so `r.ok` passes and `r.json()` throws
   because too little historical data is loaded. **Measured in the dry run:** on the default
   single-month seed (~3.17M rows) the WHERE-vs-HAVING fault is not observable — the full
   scan runs in ~300-560ms, indistinguishable from the baseline. Seed several months before
-  demoing fault 03, or lead the break-and-fix with fault 01 / fault 02 (which reproduce
-  instantly) and treat fault 03 as an at-scale illustration.
+  demoing fault 03, or stick with fault 01 (which reproduces instantly) and treat fault 03
+  as an at-scale illustration.
 - Fault 01 produces no backend trace at all, and the bad request returns 200 `text/html`
   via the SPA fallback rather than a 404; attendees may search traces forever. Nudge them
   to the browser console / Network tab, where the JSON parse error and the `text/html`

--- a/workshops/build_workshop/playbook/content/docs/learner/06b-ai-sre-librechat.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/06b-ai-sre-librechat.mdx
@@ -126,12 +126,12 @@ reads the source via the GitHub MCP and pinpoints the offending code in
 ## Wrap-up
 
 You now have a chat-native SRE agent that reasons across telemetry and code — the same
-pattern teams use to shorten incident triage. Leave fault 01 checked out: module 07 switches
-to fault 02 so you can apply the same workflow to a new incident instead of repeating this
-diagnosis.
+pattern teams use to shorten incident triage. Leave fault 01 checked out: module 07 picks
+up this same incident and completes the workflow — confirm it in ClickStack, apply the
+fix, and watch the app recover.
 
 ## End state
 
 The LibreChat SRE agent is ready to investigate fault scenarios and verify their fixes.
-Continue directly to [07 Break and fix](/docs/learner/07-break-and-fix), select fault 02,
-and turn this first diagnosis into a repeatable test-and-remediate workflow.
+Continue directly to [07 Break and fix](/docs/learner/07-break-and-fix) to turn this
+diagnosis into the full incident workflow: confirm, fix, and verify recovery.

--- a/workshops/build_workshop/playbook/content/docs/learner/07-break-and-fix.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/07-break-and-fix.mdx
@@ -5,20 +5,18 @@ description: Check out a fault branch, watch something break, diagnose it with t
 
 ## Starting point
 
-This is the only module with a branch switch. From the `app` directory, pick a fault,
-check it out, and rebuild with the observability overlay so the failure shows up in
-telemetry. **Use fault 02 if you completed module 06b**, where fault 01 was already
-diagnosed. Otherwise, fault 02 is the recommended first incident and fault 01 is a
-reliable frontend alternative:
+This is the only module with a branch switch. From the `app` directory, check out
+fault 01 and rebuild with the observability overlay so the failure shows up in
+telemetry:
 
 ```bash
-git checkout fault/02-zone-stats-500   # or fault/01-map-not-loading
+git checkout fault/01-map-not-loading
 docker compose --env-file .env.workshop \
   -f docker-compose.workshop.yml -f docker-compose.otel.yml up -d --build
 ```
 
-Fault 03 is an instructor-led, at-scale option: it needs the full roughly 30-million-row
-dataset to time out reliably and may look healthy with the default sample seed.
+(If you completed optional module 06b, fault 01 is already checked out — just make sure
+the stack was rebuilt with the overlay.)
 
 Budget about **20 minutes**.
 
@@ -43,17 +41,12 @@ and confirm the app recovers.
 
 ### fault branch
 
-The three fault branches each break a different part of the app. Here is how you know the
-fault is active (observable behavior only — the diagnosis is the exercise):
+The fault branch breaks one part of the app. Here is how you know the fault is active
+(observable behavior only — the diagnosis is the exercise):
 
 - `fault/01-map-not-loading` — the zone map stays empty while everything else works.
-- `fault/02-zone-stats-500` — the map choropleth empties and `/api/metrics/zone_stats`
-  returns 500 for pickup grouping; sibling cards keep working.
-- `fault/03-slow-dashboard` — with the full roughly 30-million-row dataset, the "What's
-  happening now" trend card times out (504) while sibling cards stay fast. With the default
-  sample seed, use this only as a query-plan exercise because it may not fail visibly.
 
-Check one out (see Starting point) and let the stack run long enough for the symptom to
+Check it out (see Starting point) and let the stack run long enough for the symptom to
 surface in the dashboards and in ClickStack.
 
 ## Step 2 — Diagnose with the AI SRE
@@ -69,17 +62,10 @@ Something is wrong with the app: users are seeing errors. Using the clickstack M
 Then ask your own follow-up question about blast radius or timeline — this is your open
 step.
 
-Confirm the fault in the signal that matches your scenario:
-
-- **Fault 01:** open **Client Sessions** in the HyperDX sidebar and pick your session. You
-  will see the front-end `console.error`, the failed resource load, and a replay of the
-  empty map. The backend dashboard and alert can stay healthy because this request never
-  reaches FastAPI.
-- **Fault 02:** open the failing `/api/metrics/zone_stats` trace and its matching backend
-  error log. The SRE dashboard error rate should rise and its alert may fire.
-- **Fault 03 (full dataset only):** open the slow or timed-out trend trace and compare its
-  latency and SQL with a fast sibling request. The latency/error signal should rise; the
-  exact alert behavior depends on the threshold you chose in module 06.
+Confirm the fault in the telemetry: open **Client Sessions** in the HyperDX sidebar and
+pick your session. You will see the front-end `console.error`, the failed resource load,
+and a replay of the empty map. The backend dashboard and alert can stay healthy because
+this request never reaches FastAPI.
 
 ![ClickStack Client Sessions: an anonymous session flagged "1 Errors, 92 Events" with a highlighted console.error "ZoneMap: failed to load…" in the event timeline and a session-replay player showing the app with the broken map](/screenshots/07-client-session-error.png)
 
@@ -96,16 +82,15 @@ you want the reference). Rebuild the affected service:
 docker compose --env-file .env.workshop -f docker-compose.workshop.yml -f docker-compose.otel.yml up -d --build
 ```
 
-You should see the symptom clear in the UI (the map loads, the 500 stops, or the slow
-card responds again). For backend faults, the error or latency signal on your SRE dashboard
-should fall back to baseline within a minute or two. For fault 01, verify a fresh browser
-session has no new `ZoneMap` error; the backend signal is expected to remain unchanged.
+You should see the symptom clear in the UI: the map loads again. Verify a fresh browser
+session records no new `ZoneMap` error in Client Sessions; the backend signal is expected
+to remain unchanged, because this fault never reached FastAPI.
 
 ## How to verify you are done
 
 - The agent named the correct root cause and cited telemetry as evidence.
-- After the fix, the scenario-specific signal above returns to baseline.
-- For a backend fault that crossed its threshold, the alert from module 06 clears.
+- After the fix, the map renders and a fresh browser session shows no new `ZoneMap` error
+  in Client Sessions.
 
 ## Wrap-up
 


### PR DESCRIPTION
## Summary
- Module 07 (Break and fix) now simply uses `fault/01-map-not-loading` — the fault-02-first recommendation and the "use fault 02 if you completed 06b" branching are removed.
- **Learner 07**: one checkout command, one symptom description, and a single fault-01 confirm/fix/verify path (Client Sessions → `console.error` → replay; map loads after the fix; backend signal expected unchanged).
- **Instructor 07**: timing, talk track, and answer-key intro name fault 01 as the lab's incident; faults 02/03 stay documented as optional extras and their answer-key sections are unchanged.
- **Learner 06b**: wrap-up/end state now hand off to module 07 continuing the same fault-01 incident (confirm → fix → verify) instead of telling participants to switch to fault 02.

## Why
One single-track incident keeps the room in sync and pairs cleanly with optional module 06b, which already diagnoses fault 01 — module 07 completes that same incident instead of forking into per-fault instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)