### PR TITLE
docs: clarify chctl authentication and preflight paths

### DIFF
--- a/workshops/build_workshop/app/README.md
+++ b/workshops/build_workshop/app/README.md
@@ -39,6 +39,9 @@ Run the preflight check first — it verifies Docker, the effective ports, your
 `.env.workshop`, and Cloud connectivity, and must report `READY` before you start:
 
 ```bash
+# From the ClickHouse_Demos repository root:
+cd workshops/build_workshop/app
+
 cp .env.workshop.example .env.workshop     # fill in your ClickHouse Cloud values
 ./preflight.sh                             # must print "Overall: READY" (exit 0)
 

--- a/workshops/build_workshop/app/README.md
+++ b/workshops/build_workshop/app/README.md
@@ -39,8 +39,8 @@ Run the preflight check first — it verifies Docker, the effective ports, your
 `.env.workshop`, and Cloud connectivity, and must report `READY` before you start:
 
 ```bash
-# From the ClickHouse_Demos repository root:
-cd workshops/build_workshop/app
+# From anywhere inside the cloned ClickHouse_Demos repository:
+cd "$(git rev-parse --show-toplevel)/workshops/build_workshop/app"
 
 cp .env.workshop.example .env.workshop     # fill in your ClickHouse Cloud values
 ./preflight.sh                             # must print "Overall: READY" (exit 0)

--- a/workshops/build_workshop/playbook/content/docs/instructor/05-clickstack.mdx
+++ b/workshops/build_workshop/playbook/content/docs/instructor/05-clickstack.mdx
@@ -22,8 +22,9 @@ collector as early as this module allows and keep it running.
 
 - OTLP host ports 4317/4318 already in use: have them set `OTEL_GRPC_HOST_PORT` /
   `OTEL_HTTP_HOST_PORT` in `.env.workshop` (preflight suggests values, e.g. 24317/24318)
-  and re-run `./preflight.sh`; the back end reaches the collector in-network, so the
-  remap is safe.
+  and, from the `ClickHouse_Demos` repository root, run
+  `cd workshops/build_workshop/app && ./preflight.sh`; the back end reaches the collector
+  in-network, so the remap is safe.
 - Collector overlay not started (forgot the second `-f docker-compose.otel.yml`), so
   nothing arrives in HyperDX.
 - `OTLP_AUTH_TOKEN` mismatch, or missing `CLICKHOUSE_*` in `.env.workshop` (the collector

--- a/workshops/build_workshop/playbook/content/docs/instructor/05-clickstack.mdx
+++ b/workshops/build_workshop/playbook/content/docs/instructor/05-clickstack.mdx
@@ -22,9 +22,9 @@ collector as early as this module allows and keep it running.
 
 - OTLP host ports 4317/4318 already in use: have them set `OTEL_GRPC_HOST_PORT` /
   `OTEL_HTTP_HOST_PORT` in `.env.workshop` (preflight suggests values, e.g. 24317/24318)
-  and, from the `ClickHouse_Demos` repository root, run
-  `cd workshops/build_workshop/app && ./preflight.sh`; the back end reaches the collector
-  in-network, so the remap is safe.
+  and, from anywhere inside the cloned repository, run
+  `cd "$(git rev-parse --show-toplevel)/workshops/build_workshop/app" && ./preflight.sh`;
+  the back end reaches the collector in-network, so the remap is safe.
 - Collector overlay not started (forgot the second `-f docker-compose.otel.yml`), so
   nothing arrives in HyperDX.
 - `OTLP_AUTH_TOKEN` mismatch, or missing `CLICKHOUSE_*` in `.env.workshop` (the collector

--- a/workshops/build_workshop/playbook/content/docs/learner/00-setup.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/00-setup.mdx
@@ -91,8 +91,8 @@ scenarios in module 07. The app is complete, so there is no other per-module che
   Compose fills unset variables from `.env.workshop`, but a value you have `export`ed in
   your shell WINS over the file. If `OPENAI_API_KEY`, any `LANGFUSE_*`, or
   `CLICKHOUSE_PASSWORD` is exported in the shell you run `docker compose` from, `unset` it
-  first so the file's value is used. (`workshops/build_workshop/app/preflight.sh` warns
-  when it detects this.)
+  first so the file's value is used. (`./preflight.sh` in the current
+  `ClickHouse_Demos/workshops/build_workshop/app` directory warns when it detects this.)
 </Callout>
 
 **You should now have:** the repo cloned, a terminal in the `app` directory, and a
@@ -219,7 +219,7 @@ confirms that the credentials actually work before you continue.
 </Callout>
 
 **You should now have:** `clickhousectl --version` printing a version number,
-`chctl cloud auth status` showing read/write API-key authentication, and
+`chctl cloud auth status` showing API-key credentials are configured, and
 `chctl cloud org list` returning your Cloud organization.
 
 ### Step 6 - Load ClickHouse skills and docs into your agent

--- a/workshops/build_workshop/playbook/content/docs/learner/00-setup.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/00-setup.mdx
@@ -428,16 +428,17 @@ auto-recharge off, and `OPENAI_API_KEY` filled in.
 ### Step 10 - Run the preflight check, then start the stack
 
 Everything the app needs is now in `.env.workshop`. Before starting the stack, run the
-preflight check from `ClickHouse_Demos/workshops/build_workshop/app`. If your terminal is
-at the `ClickHouse_Demos` repository root, enter the app directory first. It verifies
+preflight check from `ClickHouse_Demos/workshops/build_workshop/app`. The command below
+enters that directory whether your terminal is at the repository root or already inside
+the app. It verifies
 Docker (including that the daemon can actually start a container), that your effective
 host ports are free, that
 `.env.workshop` has the required values, and that your ClickHouse Cloud service is
 reachable - each as a PASS, WARN, or FAIL with a one-line fix hint:
 
 ```bash
-# From the ClickHouse_Demos repository root:
-cd workshops/build_workshop/app
+# From anywhere inside the cloned ClickHouse_Demos repository:
+cd "$(git rev-parse --show-toplevel)/workshops/build_workshop/app"
 ./preflight.sh
 ```
 

--- a/workshops/build_workshop/playbook/content/docs/learner/00-setup.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/00-setup.mdx
@@ -21,7 +21,8 @@ built into these materials.
   and OpenAI. Each takes 5 to 10 minutes on its own, mostly waiting on email or phone
   verification. If you create them before the session (the links are all in this module),
   you arrive with keys in hand and the 25 minutes is plenty. If not, come to the staffed
-  setup clinic before doors open - or, on your own, lean on `./preflight.sh` (Step 10) and
+  setup clinic before doors open - or, on your own, lean on the `./preflight.sh` check in
+  `ClickHouse_Demos/workshops/build_workshop/app` (Step 10) and
   the [Troubleshooting](/docs/learner/troubleshooting) page, which lists every setup failure
   seen in testing with its fix.
 </Callout>
@@ -90,7 +91,8 @@ scenarios in module 07. The app is complete, so there is no other per-module che
   Compose fills unset variables from `.env.workshop`, but a value you have `export`ed in
   your shell WINS over the file. If `OPENAI_API_KEY`, any `LANGFUSE_*`, or
   `CLICKHOUSE_PASSWORD` is exported in the shell you run `docker compose` from, `unset` it
-  first so the file's value is used. (`./preflight.sh` warns when it detects this.)
+  first so the file's value is used. (`workshops/build_workshop/app/preflight.sh` warns
+  when it detects this.)
 </Callout>
 
 **You should now have:** the repo cloned, a terminal in the `app` directory, and a
@@ -159,8 +161,8 @@ after you leave the screen, so save both somewhere safe now.
 {/* screenshot: api-keys-page */}
 
 
-**You should now have:** a Key ID and Key secret saved outside the repo. (These do not go
-in `.env.workshop`; you paste them into `clickhousectl` when it prompts.)
+**You should now have:** a Key ID and Key secret saved outside the repo. These do not go
+in `.env.workshop`; you use them to authenticate `chctl` in the next step.
 
 ### Step 5 - Install clickhousectl
 
@@ -182,13 +184,43 @@ clickhousectl --version
 You should see a version string like `clickhousectl version 0.x.y`. If the shell reports
 `command not found`, the `~/.local/bin` directory is not on your `PATH` yet.
 
-<Callout title="Run cloud commands from one directory">
-  `clickhousectl` stores its login tokens relative to the current working directory. Pick
-  one directory - the `app` directory is a good choice - and run every
-  `clickhousectl cloud ...` command from there so you stay authenticated.
+Now authenticate the CLI to your ClickHouse Cloud organization with the **Key ID** and
+**Key secret** from Step 4. The masked interactive prompt is the safest option:
+
+```bash
+chctl cloud auth login --interactive
+```
+
+For a non-interactive login, replace both placeholders, including the angle brackets:
+
+```bash
+chctl cloud auth login --api-key <key> --api-secret <secret>
+```
+
+The non-interactive command can expose the secret in shell history and process listings,
+so use the interactive prompt unless you are running trusted automation. Then verify both
+the configured auth mode and a real request to the Cloud API:
+
+```bash
+chctl cloud auth status
+chctl cloud org list
+```
+
+The login must use the organization API key rather than the default browser OAuth flow:
+OAuth is read-only, while module 03 needs write access to create managed Postgres and a
+ClickPipe. `auth status` confirms that API-key authentication is configured; `org list`
+confirms that the credentials actually work before you continue.
+
+<Callout title="Keep API-key commands in the app directory">
+  `clickhousectl` saves API-key credentials in `.clickhouse/credentials.json` relative to
+  the current directory and creates `.clickhouse/.gitignore` to keep them out of Git. Run
+  the login and every later `clickhousectl cloud ...` command from the `app` directory.
+  Never share or copy the credentials file.
 </Callout>
 
-**You should now have:** `clickhousectl --version` printing a version number.
+**You should now have:** `clickhousectl --version` printing a version number,
+`chctl cloud auth status` showing read/write API-key authentication, and
+`chctl cloud org list` returning your Cloud organization.
 
 ### Step 6 - Load ClickHouse skills and docs into your agent
 
@@ -396,12 +428,16 @@ auto-recharge off, and `OPENAI_API_KEY` filled in.
 ### Step 10 - Run the preflight check, then start the stack
 
 Everything the app needs is now in `.env.workshop`. Before starting the stack, run the
-preflight check from the `app` directory. It verifies Docker (including that the daemon
-can actually start a container), that your effective host ports are free, that
+preflight check from `ClickHouse_Demos/workshops/build_workshop/app`. If your terminal is
+at the `ClickHouse_Demos` repository root, enter the app directory first. It verifies
+Docker (including that the daemon can actually start a container), that your effective
+host ports are free, that
 `.env.workshop` has the required values, and that your ClickHouse Cloud service is
 reachable - each as a PASS, WARN, or FAIL with a one-line fix hint:
 
 ```bash
+# From the ClickHouse_Demos repository root:
+cd workshops/build_workshop/app
 ./preflight.sh
 ```
 

--- a/workshops/build_workshop/playbook/content/docs/learner/03-realtime-cdc.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/03-realtime-cdc.mdx
@@ -36,19 +36,17 @@ module 00 — the org API key authenticates this), create a managed Postgres ins
 Use the **same region as your ClickHouse Cloud service** so the pipe stays in-region:
 
 <Callout title="Not authenticated? Log in with your organization API key">
-  If `clickhousectl` reports that you are not authenticated, log in first with the Key ID
-  and Key secret you created in module 00:
+  If `clickhousectl` reports that you are not authenticated, return to the `app` directory
+  and log in again with the Key ID and Key secret you created in module 00:
 
   ```bash
-  clickhousectl cloud auth login --api-key YOUR_KEY --api-secret YOUR_SECRET
+  chctl cloud auth login --interactive
+  chctl cloud org list
   ```
 
-  Or set them as environment variables instead:
-
-  ```bash
-  export CLICKHOUSE_CLOUD_API_KEY=your-key
-  export CLICKHOUSE_CLOUD_API_SECRET=your-secret
-  ```
+  The masked prompt safely replaces stale saved credentials, and `org list` verifies them
+  against the Cloud API. Module 00 also shows the non-interactive `--api-key` /
+  `--api-secret` form for trusted automation.
 </Callout>
 
 ```bash

--- a/workshops/build_workshop/playbook/content/docs/learner/05-clickstack.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/05-clickstack.mdx
@@ -43,11 +43,13 @@ That single-signs you on into HyperDX.
 
 <Callout title="Check the collector ports first">
   The collector publishes OTLP on host ports **4317** and **4318**, which are commonly
-  already in use. If `./preflight.sh` in module 00 WARNed on them, set
+  already in use. If `./preflight.sh` in `ClickHouse_Demos/workshops/build_workshop/app`
+  WARNed on them in module 00, set
   `OTEL_GRPC_HOST_PORT` and `OTEL_HTTP_HOST_PORT` in `.env.workshop` to the values
   preflight suggests (for example `24317` / `24318`) before starting the overlay. The
-  back end reaches the collector in-network, so remapping the host ports is safe. Re-run
-  `./preflight.sh` to confirm the ports are clear.
+  back end reaches the collector in-network, so remapping the host ports is safe. From
+  the `ClickHouse_Demos` repository root, re-run
+  `cd workshops/build_workshop/app && ./preflight.sh` to confirm the ports are clear.
 </Callout>
 
 ### `.env.workshop` and `docker-compose.otel.yml`

--- a/workshops/build_workshop/playbook/content/docs/learner/05-clickstack.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/05-clickstack.mdx
@@ -63,8 +63,9 @@ flowing once the collector overlay is running in Step 2.)
   `OTEL_GRPC_HOST_PORT` and `OTEL_HTTP_HOST_PORT` in `.env.workshop` to the values
   preflight suggests (for example `24317` / `24318`) before starting the overlay. The
   back end reaches the collector in-network, so remapping the host ports is safe. From
-  the `ClickHouse_Demos` repository root, re-run
-  `cd workshops/build_workshop/app && ./preflight.sh` to confirm the ports are clear.
+  anywhere inside the cloned repository, re-run
+  `cd "$(git rev-parse --show-toplevel)/workshops/build_workshop/app" && ./preflight.sh`
+  to confirm the ports are clear.
 </Callout>
 
 ### `.env.workshop` and `docker-compose.otel.yml`

--- a/workshops/build_workshop/playbook/content/docs/learner/self-paced.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/self-paced.mdx
@@ -17,8 +17,9 @@ depend on. Modules 04 through 09 are the same.
 An instructor normally provides two things, and each has a self-serve replacement built
 into these materials:
 
-- **The staffed setup clinic** (module 00) is replaced by `./preflight.sh`, which checks
-  everything the live bring-up trips over, and the [Troubleshooting](/docs/learner/troubleshooting)
+- **The staffed setup clinic** (module 00) is replaced by `./preflight.sh` in
+  `ClickHouse_Demos/workshops/build_workshop/app`, which checks everything the live
+  bring-up trips over, and the [Troubleshooting](/docs/learner/troubleshooting)
   page, which lists every failure seen in testing with its exact fix.
 - **Live unsticking** during a module is replaced by two things: your coding agent acting
   as instructor (below), and the instructor track as your answer key (below).

--- a/workshops/build_workshop/playbook/content/docs/learner/troubleshooting.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/troubleshooting.mdx
@@ -17,17 +17,19 @@ has a ready-to-paste prompt that turns it into your instructor.
 - **Why** - the Docker engine is wedged: the daemon responds, yet it cannot actually start
   a container. Seen with OrbStack during a live bring-up.
 - **Fix** - restart your Docker engine (Docker Desktop, OrbStack, or Colima) and wait until
-  it reports Running, then bring the stack up again. `./preflight.sh` catches this before
-  you start the stack by running a throwaway container as a test.
+  it reports Running, then bring the stack up again. From the `ClickHouse_Demos` repository
+  root, run `cd workshops/build_workshop/app && ./preflight.sh`; it catches this before you
+  start the stack by running a throwaway container as a test.
 
 ### "port is already allocated" on up
 
 - **Symptom** - `docker compose ... up` fails with `Bind for 0.0.0.0:8080 failed: port is
   already allocated` (or `:8000`, `:5432`).
 - **Why** - another process, or an old workshop container, already holds that host port.
-- **Fix** - run `./preflight.sh`. It names what is holding the port and prints the exact
-  override to set, following the base-port + 20000 convention, for example
-  `set FRONTEND_HOST_PORT=28080 in .env.workshop`. The override vars are
+- **Fix** - from the `ClickHouse_Demos` repository root, run
+  `cd workshops/build_workshop/app && ./preflight.sh`. It names what is holding the port
+  and prints the exact override to set, following the base-port + 20000 convention, for
+  example `set FRONTEND_HOST_PORT=28080 in .env.workshop`. The override vars are
   `FRONTEND_HOST_PORT`, `BACKEND_HOST_PORT`, `POSTGRES_HOST_PORT`, and for the observability
   overlay `OTEL_GRPC_HOST_PORT` / `OTEL_HTTP_HOST_PORT`. Set the suggested value, re-run
   preflight, then start the stack. Only the host ports move; the in-container ports are

--- a/workshops/build_workshop/playbook/content/docs/learner/troubleshooting.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/troubleshooting.mdx
@@ -17,19 +17,21 @@ has a ready-to-paste prompt that turns it into your instructor.
 - **Why** - the Docker engine is wedged: the daemon responds, yet it cannot actually start
   a container. Seen with OrbStack during a live bring-up.
 - **Fix** - restart your Docker engine (Docker Desktop, OrbStack, or Colima) and wait until
-  it reports Running, then bring the stack up again. From the `ClickHouse_Demos` repository
-  root, run `cd workshops/build_workshop/app && ./preflight.sh`; it catches this before you
-  start the stack by running a throwaway container as a test.
+  it reports Running, then bring the stack up again. From anywhere inside the cloned
+  repository, run
+  `cd "$(git rev-parse --show-toplevel)/workshops/build_workshop/app" && ./preflight.sh`;
+  it catches this before you start the stack by running a throwaway container as a test.
 
 ### "port is already allocated" on up
 
 - **Symptom** - `docker compose ... up` fails with `Bind for 0.0.0.0:8080 failed: port is
   already allocated` (or `:8000`, `:5432`).
 - **Why** - another process, or an old workshop container, already holds that host port.
-- **Fix** - from the `ClickHouse_Demos` repository root, run
-  `cd workshops/build_workshop/app && ./preflight.sh`. It names what is holding the port
-  and prints the exact override to set, following the base-port + 20000 convention, for
-  example `set FRONTEND_HOST_PORT=28080 in .env.workshop`. The override vars are
+- **Fix** - from anywhere inside the cloned repository, run
+  `cd "$(git rev-parse --show-toplevel)/workshops/build_workshop/app" && ./preflight.sh`.
+  It names what is holding the port and prints the exact override to set, following the
+  base-port + 20000 convention, for example
+  `set FRONTEND_HOST_PORT=28080 in .env.workshop`. The override vars are
   `FRONTEND_HOST_PORT`, `BACKEND_HOST_PORT`, `POSTGRES_HOST_PORT`, and for the observability
   overlay `OTEL_GRPC_HOST_PORT` / `OTEL_HTTP_HOST_PORT`. Set the suggested value, re-run
   preflight, then start the stack. Only the host ports move; the in-container ports are


### PR DESCRIPTION
## Summary

- add the complete `chctl` organization API-key login flow to module 00, including the requested non-interactive command, a masked interactive default, and an API-backed verification
- align module 03 re-authentication with the safe saved-credential flow
- make every participant-facing preflight instruction point to `workshops/build_workshop/app` with a command that works from anywhere inside the cloned repository
- retain all target-branch changes from merged PRs #29 through #33 in the tested release tree

## Test Coverage

- `chctl cloud auth login`, `auth status`, and `org list` syntax verified against the installed CLI help
- preflight directory command verified from both repository root and `app`
- backend zone-filter SQL regression assertion passed
- 28 backend unit tests passed; 43 tests collected successfully

## Pre-Landing Review

- structured checklist: no remaining issues
- adversarial review: clean after fixing shell-secret, credential verification, and path-state findings
- Codex challenge: clean after final fixes

## Verification Results

- `npm run types:check` passed
- production playbook build passed and generated all 99 static pages
- merged-PR ancestry verified for PRs #29, #30, #31, #32, and #33

## Documentation

- `learner/00-setup.mdx`: complete CLI authentication and location-safe preflight instructions
- `learner/03-realtime-cdc.mdx`: safe re-authentication recovery
- learner troubleshooting, self-paced, ClickStack, instructor notes, and app README: explicit preflight location and runnable commands

## Test plan

- [x] MDX generation and TypeScript checks
- [x] production Next.js build
- [x] backend unit tests
- [x] independent adversarial review
