### PR TITLE
Workshop: show live CDC and ClickStack patterns by default

### DIFF
--- a/workshops/build_workshop/app/.env.workshop.example
+++ b/workshops/build_workshop/app/.env.workshop.example
@@ -26,26 +26,23 @@ CLICKHOUSE_CONNECT_TIMEOUT=10
 # The loadgen (pg-trip-writer) writes synthetic trips here; a Postgres CDC
 # ClickPipe then captures them into ClickHouse Cloud.
 #
-# PRIMARY PATH: your OWN Postgres managed by ClickHouse, created in module 03
-# with `clickhousectl cloud postgres create`. Paste the hostname and the
-# one-time password from that command's JSON output below. The connection user
-# is the instance admin, so the loadgen creates the table and publication for
-# you (no psql needed), and the instance ships with wal_level=logical + 10
-# replication slots, so CDC works out of the box.
-PGHOST=<your managed-postgres hostname from clickhousectl>
+# Start with the literal Docker service name below so the local app works in
+# modules 00-02. In module 03, replace it with the hostname returned by
+# `clickhousectl cloud postgres create`, then set the matching password and TLS
+# values. The managed connection user is the instance admin, so the loadgen
+# creates the table and publication for you (no psql needed).
+PGHOST=postgres
 PGPORT=5432
-PGDATABASE=postgres
-PGUSER=postgres
-PGPASSWORD=<one-time password printed by clickhousectl cloud postgres create>
-# Managed Postgres mandates TLS (honored natively by psycopg3/libpq). Keep 'require'.
-PGSSLMODE=require
+PGDATABASE=taxi
+PGUSER=taxi
+PGPASSWORD=taxi
+PGSSLMODE=prefer
 # Publication the ClickPipe subscribes to; the loadgen creates it on your
 # instance. Keep as-is unless a hand-out slip tells you otherwise.
 PG_PUBLICATION=pub_taxi
 #
-# LOCAL CONTAINER FALLBACK (offline dev, no managed instance): use the bundled
-# `postgres` service instead - set PGHOST=postgres, PGDATABASE=taxi, PGUSER=taxi,
-# PGPASSWORD=taxi, PGSSLMODE=prefer (matches the container credentials below).
+# LOCAL CONTAINER FALLBACK (the default above): the bundled `postgres` service
+# uses PGHOST=postgres, database/user/password=taxi, and PGSSLMODE=prefer.
 # INSTRUCTOR-SHARED FALLBACK (only if managed Postgres is unavailable in your
 # org): fill all PG* values from the hand-out slip your instructor provides.
 
@@ -87,8 +84,9 @@ OTEL_SERVICE_NAME=nyc-taxi-backend
 # console, network, session replay). The browser SDK is baked in only when the
 # otel overlay builds the frontend image (docker compose ... up -d --build).
 OTEL_FRONTEND_SERVICE_NAME=nyc-taxi-frontend
-# Backend + loadgen log verbosity (DEBUG, INFO, WARNING, ERROR).
-LOG_LEVEL=INFO
+# DEBUG exposes each successful ClickHouse query in ClickStack's Log source.
+# Warnings and errors still retain their real severity.
+LOG_LEVEL=DEBUG
 # Host ports for the collector's OTLP receivers; change only on conflicts.
 OTEL_GRPC_HOST_PORT=4317
 OTEL_HTTP_HOST_PORT=4318

--- a/workshops/build_workshop/app/OBSERVABILITY.md
+++ b/workshops/build_workshop/app/OBSERVABILITY.md
@@ -155,13 +155,13 @@ the host ports does NOT change the backend wiring.
 | `OTEL_EXPORTER_OTLP_HEADERS` | `authorization=${OTLP_AUTH_TOKEN}` | Sends the shared token back to the collector. **VERIFY-LIVE.** |
 | `OTEL_LOGS_EXPORTER` | `otlp` | Wires up the OTLP log exporter/provider. Necessary but NOT sufficient on its own — see the next row. |
 | `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED` | `true` | **Required for logs to flow.** Only when this is `true` does `opentelemetry-instrument` attach the stdlib-logging OTLP handler to the root logger; `configure_logging()` then preserves it. Without it, `otel_logs` stays empty while traces/metrics work fine. |
-| `LOG_LEVEL` | `INFO` | App + uvicorn log level (`DEBUG`/`INFO`/`WARNING`/`ERROR`). |
+| `LOG_LEVEL` | `DEBUG` | App + uvicorn log level. `DEBUG` makes successful per-query records visible in ClickStack while real retries/failures remain `WARNING`/`ERROR`. |
 
 ### Loadgen
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `LOG_LEVEL` | `INFO` | Loadgen log level. |
+| `LOG_LEVEL` | `DEBUG` | Loadgen log threshold. Its batch records are `INFO`; use the optional container-log collector to ingest them. |
 
 ## uvicorn caveat (documented)
 
@@ -185,9 +185,11 @@ dashboard, or `curl` the API), in the ClickHouse Cloud HyperDX UI:
 3. **Error traces** – trigger a failure (e.g. a query that exceeds the safety
    limits) and the `clickhouse.query` span shows `error.category` and a recorded
    exception; the matching request span is marked error.
-4. **Logs** – backend `ERROR` logs from failing ClickHouse queries appear (via
-   OTLP and/or container scraping). With `--profile container-logs`, loadgen
-   `[loadgen] inserted N trips ...` lines appear too.
+4. **Logs** – leave the Ops dashboard open with its default 5-second refresh.
+   Backend `DEBUG ... ClickHouse query ok` records appear through OTLP on every
+   refresh. Real idle-wake retries and failures retain `WARNING`/`ERROR` severity.
+   With `--profile container-logs`, loadgen `[loadgen] inserted N trips ...`
+   lines appear too.
 
 Quick smoke check without the UI:
 
@@ -213,9 +215,10 @@ ClickStack service; confirm during the first live run:
    the actual root cause — `configure_logging()` was correctly *preserving* a
    handler that was never installed); and (b) `configure_logging()` keeps that
    handler instead of evicting it. **Severity note:** successful queries log at
-   `DEBUG` (`db.py`), so with the default `LOG_LEVEL=INFO` a healthy app is quiet
-   and only WARN/ERROR records flow — which is the point (you see logs in HyperDX
-   exactly when something goes wrong). Set `LOG_LEVEL=DEBUG` to see per-query rows.
+   `DEBUG` (`db.py`). The workshop now defaults to `LOG_LEVEL=DEBUG`, so the Ops
+   dashboard's 5-second refresh produces a visible stream of successful query
+   records. Real retry and failure paths remain `WARNING`/`ERROR`; the workshop
+   does not manufacture warnings just to populate the Log source.
    The `--profile container-logs` path remains the fallback for non-instrumented
    services. **Deprecation:** OTel Python 0.64b0 logs a warning that the SDK's
    env-var-driven LoggingHandler is deprecated and "will be removed in a future

--- a/workshops/build_workshop/app/docker-compose.otel.yml
+++ b/workshops/build_workshop/app/docker-compose.otel.yml
@@ -78,7 +78,7 @@ services:
       # the root logger ONLY when this is true. Without it, otel_logs stays empty while
       # traces/metrics work (observability.py preserves the handler once it exists).
       - OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
-      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      - LOG_LEVEL=${LOG_LEVEL:-DEBUG}
 
   # Additive overlay onto the workshop `frontend`: bake the ClickStack browser SDK
   # config into the build so it captures frontend UI errors, console, network, and

--- a/workshops/build_workshop/app/frontend/src/pages/DashboardPage.tsx
+++ b/workshops/build_workshop/app/frontend/src/pages/DashboardPage.tsx
@@ -36,8 +36,8 @@ export function DashboardPage() {
   const resetFilters = (): DashboardFilters => ({
     start: utcStartOfTodayIso(),
     end: utcEndOfTodayIso(),
-    interval: "15m",
-    auto_refresh_s: 0,
+    interval: "1m",
+    auto_refresh_s: 5,
     vendor_id: undefined,
     payment_type: undefined,
     pickup_zone_id: [],
@@ -47,8 +47,8 @@ export function DashboardPage() {
   const [filters, setFilters] = useState<DashboardFilters>({
     start: utcStartOfTodayIso(),
     end: utcEndOfTodayIso(),
-    interval: "15m",
-    auto_refresh_s: 0,
+    interval: "1m",
+    auto_refresh_s: 5,
     vendor_id: undefined,
     payment_type: undefined,
     pickup_zone_id: [],
@@ -171,4 +171,3 @@ export function DashboardPage() {
     </div>
   );
 }
-

--- a/workshops/build_workshop/playbook/content/docs/learner/03-realtime-cdc.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/03-realtime-cdc.mdx
@@ -44,14 +44,16 @@ clickhousectl cloud postgres reset-password <postgres-id>
 
 ## Step 2 — Start the trip writer
 
-Put the Postgres values into `.env.workshop`:
+The app starts with the valid local literal `PGHOST=postgres`. In `.env.workshop`,
+replace that value and the local credentials with the values returned by
+`clickhousectl`:
 
 ```bash
-PGHOST=<managed-postgres-hostname>
+PGHOST=replace-with-hostname-from-clickhousectl
 PGPORT=5432
 PGDATABASE=postgres
 PGUSER=postgres
-PGPASSWORD=<one-time-password>
+PGPASSWORD=replace-with-one-time-password
 PGSSLMODE=require
 PG_PUBLICATION=pub_taxi
 ```

--- a/workshops/build_workshop/playbook/content/docs/learner/05-clickstack.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/05-clickstack.mdx
@@ -20,9 +20,8 @@ produces telemetry you can query.
 
 ## Goal
 
-App traces flowing into ClickStack and visible in HyperDX, with at least one end-to-end
-request trace you can open. Traces are the signal you verify here; application logs are
-available via `docker compose ... logs` and the optional container-logs profile.
+App traces and backend query logs flowing into ClickStack, with at least one end-to-end
+request trace and a visible stream of successful query records.
 
 ## Step 1 — Enable Managed ClickStack on your service
 
@@ -46,12 +45,10 @@ flowing once the collector overlay is running in Step 2.)
   - ClickStack's telemetry lives in a separate database on your service
     (`CLICKSTACK_DATABASE=otel`), distinct from the app's data database
     (`CLICKHOUSE_DATABASE=nyc_tlc_data`).
-  - Traces always flow over OTLP from the auto-instrumented back end and are the signal
-    you rely on here. Application logs did not deliver reliably over OTLP in testing, so
-    read them with `docker compose ... logs` (or enable the optional
-    `--profile container-logs` collector, which scrapes raw container stdout — a
-    Linux-host path; on Docker Desktop the daemon runs in a VM and that host mount may
-    not be available).
+  - Traces and backend Python logs flow over OTLP from the auto-instrumented back end.
+    The optional `--profile container-logs` collector is only for non-instrumented
+    services such as the trip writer; its Linux Docker log path may not be available on
+    Docker Desktop.
 </Callout>
 
 ## Step 2 — Run the OpenTelemetry collector overlay
@@ -86,7 +83,7 @@ in your `.env.workshop`:
 OTLP_AUTH_TOKEN=change-me-workshop-token   # shared secret securing OTLP ingest
 CLICKSTACK_DATABASE=otel                   # ClickStack's own otel_* tables
 OTEL_SERVICE_NAME=nyc-taxi-backend         # the service name shown in HyperDX
-LOG_LEVEL=INFO
+LOG_LEVEL=DEBUG                            # show successful queries in Log source
 ```
 
 The collector reuses `CLICKHOUSE_HOST` / `CLICKHOUSE_PORT` / `CLICKHOUSE_USER` /
@@ -94,12 +91,16 @@ The collector reuses `CLICKHOUSE_HOST` / `CLICKHOUSE_PORT` / `CLICKHOUSE_USER` /
 `http://otel-collector:4318` (HTTP/protobuf). To also scrape raw container stdout on a
 Linux host, add `--profile container-logs`.
 
-## Step 3 — Generate and find traffic in HyperDX
+## Step 3 — Generate and find traffic in ClickStack
 
-Click around both dashboards to generate requests, then open HyperDX and find the
-resulting traces. Follow one request end to end (front end -> back end -> ClickHouse).
-(Application logs are not in HyperDX in this setup; read them with `docker compose ...
-logs backend`.)
+Open the Ops dashboard and leave its default `1m` interval and `5s` auto-refresh running
+for about 30 seconds. Then open ClickStack:
+
+1. In **Traces**, follow one request end to end (front end -> back end -> ClickHouse).
+2. In **Logs**, select `nyc-taxi-backend` and find repeated
+   `ClickHouse query ok` records. Their timestamps should advance every refresh.
+3. Keep severity meaningful: successful queries are `DEBUG`; real idle-wake retries and
+   failures appear as `WARNING` or `ERROR`.
 
 You should see a service named `nyc-taxi-backend` appear in HyperDX, with `/api/...`
 requests showing as traces, each carrying a child `clickhouse.query` span.
@@ -113,15 +114,18 @@ requests showing as traces, each carrying a child `clickhouse.query` span.
 - A service named `nyc-taxi-backend` appears in HyperDX.
 - Requests to `/api/...` show as traces, each with a child `clickhouse.query` span
   carrying `db.statement`, `db.elapsed_ms`, and `db.rows_returned`.
+- The Log source shows fresh `DEBUG ... ClickHouse query ok` records while the Ops
+  dashboard remains open.
 - You will not see query errors here yet: a healthy, seeded app does not trip the safety
   limits, and 4xx requests never reach ClickHouse. In module 07 the injected fault makes
   an errored `clickhouse.query` span (with `error.category`) observable.
 
 ## Wrap-up
 
-The app is now observable: its behavior is recorded as traces in ClickHouse and
-explorable in HyperDX (with logs available via `docker compose ... logs` and the
-container-logs profile). That telemetry is the substrate for the AI SRE work next.
+The app is now observable: traces and backend query logs are recorded in ClickHouse and
+explorable in ClickStack. The optional container-logs profile adds stdout from the trip
+writer on compatible Linux hosts. That telemetry is the substrate for the AI SRE work
+next.
 
 ## End state
 

--- a/workshops/build_workshop/scripts/check-docs.sh
+++ b/workshops/build_workshop/scripts/check-docs.sh
@@ -8,7 +8,7 @@ fail_if_found() {
   local description=$1
   local pattern=$2
   shift 2
-  if rg -n --pcre2 "${pattern}" "$@"; then
+  if grep -RInE -- "${pattern}" "$@"; then
     echo "ERROR: ${description}" >&2
     exit 1
   fi
@@ -26,14 +26,14 @@ fail_if_found \
 
 fail_if_found \
   "learners must not be told to edit SQL comments or execute a hidden SQL file" \
-  '(comment|uncomment).*(sql|variant)|(?:run|execute|open).*(?:db/cloud|\.sql file)' \
+  '(comment|uncomment).*(sql|variant)|(run|execute|open).*(db/cloud|\.sql file)' \
   "${CONTENT}/learner"
 
 require_fixed() {
   local description=$1
   local literal=$2
   local file=$3
-  if ! rg -Fq -- "${literal}" "${file}"; then
+  if ! grep -Fq -- "${literal}" "${file}"; then
     echo "ERROR: ${description}" >&2
     exit 1
   fi
@@ -45,7 +45,7 @@ require_count() {
   local literal=$3
   local file=$4
   local actual
-  actual=$(rg -F -c -- "${literal}" "${file}" || true)
+  actual=$(grep -F -c -- "${literal}" "${file}" || true)
   if [ "${actual}" -ne "${expected}" ]; then
     echo "ERROR: ${description} (expected ${expected}, found ${actual})" >&2
     exit 1
@@ -88,7 +88,8 @@ require_count \
 
 # MCP server definitions belong in setup. Later modules should use or link to
 # that setup instead of asking learners to configure the same endpoint again.
-if rg -n 'mcpServers|"clickhouse"\s*:\s*\{' "${CONTENT}/learner" --glob '!00-setup.mdx'; then
+if grep -RInE --exclude='00-setup.mdx' \
+  'mcpServers|"clickhouse"[[:space:]]*:[[:space:]]*\{' "${CONTENT}/learner"; then
   echo "ERROR: learner MCP server configuration must appear only in 00-setup.mdx" >&2
   exit 1
 fi

--- a/workshops/build_workshop/scripts/check-docs.sh
+++ b/workshops/build_workshop/scripts/check-docs.sh
@@ -29,6 +29,63 @@ fail_if_found \
   '(comment|uncomment).*(sql|variant)|(?:run|execute|open).*(?:db/cloud|\.sql file)' \
   "${CONTENT}/learner"
 
+require_fixed() {
+  local description=$1
+  local literal=$2
+  local file=$3
+  if ! rg -Fq -- "${literal}" "${file}"; then
+    echo "ERROR: ${description}" >&2
+    exit 1
+  fi
+}
+
+require_count() {
+  local description=$1
+  local expected=$2
+  local literal=$3
+  local file=$4
+  local actual
+  actual=$(rg -F -c -- "${literal}" "${file}" || true)
+  if [ "${actual}" -ne "${expected}" ]; then
+    echo "ERROR: ${description} (expected ${expected}, found ${actual})" >&2
+    exit 1
+  fi
+}
+
+require_fixed \
+  "the copied app environment must use the working local Postgres service literal" \
+  'PGHOST=postgres' \
+  "${ROOT}/app/.env.workshop.example"
+
+for literal in 'PGDATABASE=taxi' 'PGUSER=taxi' 'PGPASSWORD=taxi' 'PGSSLMODE=prefer'; do
+  require_fixed \
+    "the copied app environment must use the complete local Postgres connection tuple" \
+    "${literal}" \
+    "${ROOT}/app/.env.workshop.example"
+done
+
+require_fixed \
+  "the app environment must expose successful query logs to ClickStack" \
+  'LOG_LEVEL=DEBUG' \
+  "${ROOT}/app/.env.workshop.example"
+
+require_fixed \
+  "the observability overlay default must expose successful query logs" \
+  'LOG_LEVEL=${LOG_LEVEL:-DEBUG}' \
+  "${ROOT}/app/docker-compose.otel.yml"
+
+require_count \
+  "initial and reset Ops dashboard intervals must both be one minute" \
+  2 \
+  'interval: "1m"' \
+  "${ROOT}/app/frontend/src/pages/DashboardPage.tsx"
+
+require_count \
+  "initial and reset Ops dashboard states must both refresh every five seconds" \
+  2 \
+  'auto_refresh_s: 5' \
+  "${ROOT}/app/frontend/src/pages/DashboardPage.tsx"
+
 # MCP server definitions belong in setup. Later modules should use or link to
 # that setup instead of asking learners to configure the same endpoint again.
 if rg -n 'mcpServers|"clickhouse"\s*:\s*\{' "${CONTENT}/learner" --glob '!00-setup.mdx'; then


### PR DESCRIPTION
Makes the copied app environment use the complete local Postgres literal tuple, then tells Module 03 to replace it with clickhousectl managed values. Sets the Ops dashboard initial and reset state to a 1m interval with 5s auto-refresh. Defaults backend OTLP logging to DEBUG so successful ClickHouse query records appear in ClickStack Logs while real retries and failures retain WARNING or ERROR severity. Adds policy regression checks. Local evidence: Compose config passed; docs and shell checks passed; 28 backend tests passed; app frontend production build passed; playbook MDX/types and 99-page production build passed.