### PR TITLE
feat(app): reskin the NYC-taxi app with a ClickHouse Click UI dark theme

### DIFF
--- a/workshops/build_workshop/app/frontend/index.html
+++ b/workshops/build_workshop/app/frontend/index.html
@@ -1,9 +1,16 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-bs-theme="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>NYC Taxi Ops War Room</title>
+    <meta name="color-scheme" content="dark" />
+    <title>NYC Taxi Ops · ClickHouse</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/workshops/build_workshop/app/frontend/src/App.tsx
+++ b/workshops/build_workshop/app/frontend/src/App.tsx
@@ -1,41 +1,49 @@
-import { Link, Navigate, Route, Routes } from "react-router-dom";
+import { NavLink, Navigate, Route, Routes } from "react-router-dom";
 
 import { DashboardPage } from "./pages/DashboardPage";
 import { HistoricalPage } from "./pages/HistoricalPage";
 
 export function App() {
   return (
-    <div className="container-fluid py-3">
-      <div className="d-flex align-items-center justify-content-between mb-2">
-        <div>
-          <div className="h3 mb-0">NYC Taxi Ops War Room</div>
-          <div className="text-secondary">ClickHouse BUILD Workshop (ClickHouse + FastAPI + React)</div>
+    <div className="app-shell">
+      <header className="app-header">
+        <div className="brand">
+          {/* Official ClickHouse mark (Click UI Clickhouse.tsx): four rounded bars + one
+              short bar, monochrome. currentColor renders it white on the dark header. */}
+          <svg className="brand-logo" viewBox="0 0 54 54" fill="none" role="img" aria-label="ClickHouse">
+            <rect width="5.9998" height="53.9982" rx="1.45943" fill="currentColor" />
+            <rect x="12" width="5.9998" height="53.9982" rx="1.45943" fill="currentColor" />
+            <rect x="24.001" width="5.9998" height="53.9982" rx="1.45943" fill="currentColor" />
+            <rect x="35.998" width="5.9998" height="53.9982" rx="1.45943" fill="currentColor" />
+            <rect x="48.001" y="21.0005" width="5.9998" height="11.9996" rx="1.45943" fill="currentColor" />
+          </svg>
+          <span className="brand-name">ClickHouse</span>
+          <span className="brand-sep" aria-hidden="true">/</span>
+          <span className="app-name">NYC Taxi Ops</span>
+          <span className="app-badge">BUILD Workshop</span>
         </div>
-        <div className="d-flex gap-2">
-          <a className="btn btn-outline-secondary btn-sm" href="/api/docs" target="_blank" rel="noreferrer">
-            API Docs
-          </a>
-        </div>
-      </div>
 
-      <ul className="nav nav-pills mb-3">
-        <li className="nav-item">
-          <Link className="nav-link" to="/">
-            Ops (Live)
-          </Link>
-        </li>
-        <li className="nav-item">
-          <Link className="nav-link" to="/historical">
+        <nav className="app-nav">
+          <NavLink to="/" end className="tab">
+            <span className="live-dot" aria-hidden="true" />
+            Ops · Live
+          </NavLink>
+          <NavLink to="/historical" className="tab">
             Historical
-          </Link>
-        </li>
-      </ul>
+          </NavLink>
+          <a className="ghost-link" href="/api/docs" target="_blank" rel="noreferrer">
+            API Docs ↗
+          </a>
+        </nav>
+      </header>
 
-      <Routes>
-        <Route path="/" element={<DashboardPage />} />
-        <Route path="/historical" element={<HistoricalPage />} />
-        <Route path="*" element={<Navigate to="/" replace />} />
-      </Routes>
+      <main className="app-main pt-3">
+        <Routes>
+          <Route path="/" element={<DashboardPage />} />
+          <Route path="/historical" element={<HistoricalPage />} />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </main>
     </div>
   );
 }

--- a/workshops/build_workshop/app/frontend/src/main.tsx
+++ b/workshops/build_workshop/app/frontend/src/main.tsx
@@ -1,5 +1,6 @@
 import "bootstrap/dist/css/bootstrap.min.css";
 import "maplibre-gl/dist/maplibre-gl.css";
+import "./theme.css";
 
 import React from "react";
 import ReactDOM from "react-dom/client";
@@ -28,10 +29,10 @@ const queryClient = new QueryClient({
 function ErrorFallback({ error }: FallbackProps) {
   const message = error instanceof Error ? error.message : String(error);
   return (
-    <div className="container-fluid py-4">
-      <div className="alert alert-danger" role="alert">
-        <div className="fw-bold">Something went wrong.</div>
-        <div className="small mt-1">{message}</div>
+    <div className="app-error">
+      <div className="app-error-card" role="alert">
+        <div className="title">Something went wrong.</div>
+        <div className="detail">{message}</div>
       </div>
     </div>
   );

--- a/workshops/build_workshop/app/frontend/src/theme.css
+++ b/workshops/build_workshop/app/frontend/src/theme.css
@@ -1,0 +1,304 @@
+/*
+  ClickHouse Click UI dark theme for the NYC Taxi Ops app.
+
+  Imported after Bootstrap in main.tsx. Rather than rewrite components, this
+  maps the Click UI token palette onto Bootstrap 5.3's CSS variables and adds
+  a thin polish layer (app shell, panels, states). Colors mirror
+  ClickHouse/click-ui src/theme/tokens/variables.dark.ts.
+*/
+
+:root {
+  /* Click UI dark palette */
+  --ch-bg: #131312;
+  --ch-surface: #1f1f1c;   /* cards / panels */
+  --ch-surface-2: #282828; /* inputs / raised */
+  --ch-surface-3: #2f2f2c; /* hover */
+  --ch-border: #323232;
+  --ch-border-strong: #414141;
+  --ch-text: #e6e7e9;
+  --ch-text-strong: #ffffff;
+  --ch-muted: #9a9ea7;
+  --ch-muted-2: #b3b6bd;
+
+  --ch-accent: #faff69;      /* ClickHouse yellow */
+  --ch-accent-strong: #eef400;
+  --ch-amber: #ffc300;
+  --ch-blue: #6d9bf3;
+  --ch-cyan: #00cbeb;
+  --ch-green: #33ff44;
+  --ch-orange: #ff7729;
+  --ch-red: #ff5353;
+
+  --ch-radius: 10px;
+  --ch-radius-sm: 7px;
+  --ch-shadow: 0 1px 0 rgba(255, 255, 255, 0.02) inset, 0 12px 28px -18px rgba(0, 0, 0, 0.8);
+  --ch-font: "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Segoe UI", system-ui, sans-serif;
+  --ch-mono: "SFMono Regular", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}
+
+/* ---- Map Click UI tokens onto Bootstrap variables ---- */
+:root,
+[data-bs-theme="dark"] {
+  --bs-body-bg: var(--ch-bg);
+  --bs-body-color: var(--ch-text);
+  --bs-body-font-family: var(--ch-font);
+  --bs-emphasis-color: var(--ch-text-strong);
+  --bs-secondary-color: var(--ch-muted);
+  --bs-tertiary-color: var(--ch-muted);
+  --bs-border-color: var(--ch-border);
+  --bs-border-color-translucent: var(--ch-border);
+  --bs-link-color: var(--ch-blue);
+  --bs-link-color-rgb: 109, 155, 243;
+  --bs-link-hover-color: #9dbcf8;
+  --bs-code-color: var(--ch-accent);
+  --bs-heading-color: var(--ch-text-strong);
+  --bs-secondary-bg: var(--ch-surface-2);
+  --bs-tertiary-bg: var(--ch-surface);
+  --bs-emphasis-color-rgb: 255, 255, 255;
+}
+
+body {
+  background-color: var(--ch-bg);
+  color: var(--ch-text);
+  font-family: var(--ch-font);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+h1, h2, h3, h4, h5, h6,
+.h1, .h2, .h3, .h4, .h5, .h6 {
+  color: var(--ch-text-strong);
+  letter-spacing: -0.01em;
+}
+.text-secondary { color: var(--ch-muted) !important; }
+::selection { background: rgba(250, 255, 105, 0.28); color: #fff; }
+
+/* ---- App shell ---- */
+.app-main { padding: 0 clamp(16px, 3vw, 40px) 48px; max-width: 1600px; margin: 0 auto; }
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 18px clamp(16px, 3vw, 40px);
+  max-width: 1600px;
+  margin: 0 auto;
+  border-bottom: 1px solid var(--ch-border);
+}
+.brand { display: flex; align-items: center; gap: 10px; min-width: 0; }
+.brand-logo { height: 20px; width: auto; display: block; flex: none; color: var(--ch-text-strong); }
+.brand-name { font-weight: 700; color: var(--ch-text-strong); letter-spacing: -0.02em; }
+.brand-sep { color: var(--ch-border-strong); }
+.app-name { font-weight: 600; color: var(--ch-text); }
+.app-badge {
+  font-family: var(--ch-mono); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--ch-accent); border: 1px solid var(--ch-border-strong);
+  padding: 3px 8px; border-radius: 100px; white-space: nowrap;
+}
+
+.app-nav { display: flex; align-items: center; gap: 6px; }
+.app-nav .tab {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 14px; border-radius: 8px;
+  color: var(--ch-muted-2); text-decoration: none; font-weight: 500; font-size: 14px;
+  border: 1px solid transparent; transition: background-color .15s, color .15s, border-color .15s;
+}
+.app-nav .tab:hover { background: var(--ch-surface-2); color: var(--ch-text); }
+.app-nav .tab.active { background: var(--ch-surface-2); color: var(--ch-text-strong); border-color: var(--ch-border-strong); }
+.app-nav .tab.active .live-dot { box-shadow: 0 0 0 0 rgba(51, 255, 68, 0.5); }
+.live-dot {
+  width: 7px; height: 7px; border-radius: 50%; background: var(--ch-green);
+  animation: livepulse 2s ease-out infinite;
+}
+@keyframes livepulse {
+  0% { box-shadow: 0 0 0 0 rgba(51, 255, 68, 0.45); }
+  70% { box-shadow: 0 0 0 6px rgba(51, 255, 68, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(51, 255, 68, 0); }
+}
+.app-nav .ghost-link {
+  color: var(--ch-muted); text-decoration: none; font-size: 13px; padding: 7px 12px; margin-left: 4px;
+  border-radius: 8px; border: 1px solid var(--ch-border);
+}
+.app-nav .ghost-link:hover { color: var(--ch-text); border-color: var(--ch-border-strong); }
+@media (prefers-reduced-motion: reduce) { .live-dot { animation: none; } }
+
+/* ---- Cards / panels ---- */
+.card {
+  --bs-card-bg: var(--ch-surface);
+  --bs-card-color: var(--ch-text);
+  --bs-card-border-color: var(--ch-border);
+  --bs-card-border-radius: var(--ch-radius);
+  --bs-card-inner-border-radius: calc(var(--ch-radius) - 1px);
+  --bs-card-cap-bg: transparent;
+  box-shadow: var(--ch-shadow);
+  transition: border-color .15s ease;
+}
+.card:hover { border-color: var(--ch-border-strong); }
+.card.shadow { box-shadow: 0 20px 50px -20px rgba(0, 0, 0, 0.85) !important; }
+
+/* Panel title: the "h5 + subtitle" header pattern used across the dashboards */
+.card-body > .d-flex > .h5,
+.card-body > .h5 { font-size: 0.98rem; font-weight: 650; }
+.card-body > .d-flex > .h5::before,
+.card-body > .h5.panel-title::before {
+  content: ""; display: inline-block; width: 3px; height: 0.9em;
+  background: var(--ch-accent); border-radius: 2px; margin-right: 9px; vertical-align: -1px;
+}
+
+/* ---- Tables ---- */
+.table {
+  --bs-table-bg: transparent;
+  --bs-table-color: var(--ch-text);
+  --bs-table-border-color: var(--ch-border);
+  --bs-table-striped-bg: rgba(255, 255, 255, 0.025);
+  --bs-table-striped-color: var(--ch-text);
+  --bs-table-hover-bg: rgba(250, 255, 105, 0.06);
+  --bs-table-hover-color: var(--ch-text-strong);
+  font-size: 0.9rem;
+}
+.table > thead th {
+  color: var(--ch-muted);
+  font-weight: 600; font-size: 0.72rem; letter-spacing: 0.05em; text-transform: uppercase;
+  border-bottom: 1px solid var(--ch-border-strong);
+  background: transparent;
+}
+.table > :not(caption) > * > * { border-bottom-color: var(--ch-border); }
+
+/* ---- Forms ---- */
+.form-label { color: var(--ch-muted-2); font-size: 0.78rem; font-weight: 600; letter-spacing: 0.02em; }
+.form-control, .form-select {
+  --bs-body-bg: var(--ch-surface-2);
+  background-color: var(--ch-surface-2);
+  border-color: var(--ch-border-strong);
+  color: var(--ch-text);
+  border-radius: var(--ch-radius-sm);
+}
+.form-control::placeholder { color: #6b6f77; }
+.form-control:focus, .form-select:focus {
+  background-color: var(--ch-surface-2);
+  border-color: var(--ch-accent);
+  color: var(--ch-text);
+  box-shadow: 0 0 0 3px rgba(250, 255, 105, 0.18);
+}
+.form-select {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%239a9ea7' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3e%3c/svg%3e");
+}
+.form-check-input {
+  background-color: var(--ch-surface-2);
+  border-color: var(--ch-border-strong);
+}
+.form-check-input:checked {
+  background-color: var(--ch-accent);
+  border-color: var(--ch-accent);
+}
+.form-check-input:focus { border-color: var(--ch-accent); box-shadow: 0 0 0 3px rgba(250, 255, 105, 0.18); }
+
+/* ---- Buttons ---- */
+.btn { --bs-btn-border-radius: var(--ch-radius-sm); font-weight: 550; }
+.btn-primary {
+  --bs-btn-bg: var(--ch-accent);
+  --bs-btn-border-color: var(--ch-accent);
+  --bs-btn-color: #14130f;
+  --bs-btn-hover-bg: var(--ch-accent-strong);
+  --bs-btn-hover-border-color: var(--ch-accent-strong);
+  --bs-btn-hover-color: #14130f;
+  --bs-btn-active-bg: var(--ch-accent-strong);
+  --bs-btn-active-color: #14130f;
+  --bs-btn-disabled-bg: #5c5f2b;
+  --bs-btn-disabled-border-color: #5c5f2b;
+  --bs-btn-disabled-color: rgba(20, 19, 15, 0.6);
+}
+.btn-outline-primary {
+  --bs-btn-color: var(--ch-accent);
+  --bs-btn-border-color: var(--ch-border-strong);
+  --bs-btn-hover-bg: rgba(250, 255, 105, 0.12);
+  --bs-btn-hover-border-color: var(--ch-accent);
+  --bs-btn-hover-color: var(--ch-accent);
+  --bs-btn-active-bg: rgba(250, 255, 105, 0.16);
+  --bs-btn-active-color: var(--ch-accent);
+}
+.btn-outline-secondary {
+  --bs-btn-color: var(--ch-muted-2);
+  --bs-btn-border-color: var(--ch-border-strong);
+  --bs-btn-hover-bg: var(--ch-surface-3);
+  --bs-btn-hover-border-color: var(--ch-border-strong);
+  --bs-btn-hover-color: var(--ch-text-strong);
+  --bs-btn-active-bg: var(--ch-surface-3);
+  --bs-btn-active-color: var(--ch-text-strong);
+}
+.btn:focus-visible { box-shadow: 0 0 0 3px rgba(250, 255, 105, 0.35); }
+.btn-close { filter: invert(1) grayscale(1) brightness(1.6); opacity: 0.6; }
+.btn-close:hover { opacity: 1; }
+
+/* ---- Nav pills (fallback if any remain) ---- */
+.nav-pills {
+  --bs-nav-pills-link-active-bg: var(--ch-surface-2);
+  --bs-nav-pills-link-active-color: var(--ch-text-strong);
+  --bs-nav-link-color: var(--ch-muted-2);
+  --bs-nav-link-hover-color: var(--ch-text);
+}
+
+/* ---- Badges ---- */
+.badge.text-bg-primary, .badge.bg-primary { background-color: var(--ch-accent) !important; color: #14130f !important; }
+.badge.text-bg-secondary, .badge.bg-secondary { background-color: var(--ch-surface-3) !important; color: var(--ch-text) !important; }
+
+/* ---- Alerts ---- */
+.alert-danger {
+  --bs-alert-bg: rgba(255, 83, 83, 0.1);
+  --bs-alert-border-color: rgba(255, 83, 83, 0.35);
+  --bs-alert-color: #ffb3b3;
+}
+.alert-warning {
+  --bs-alert-bg: rgba(255, 119, 41, 0.1);
+  --bs-alert-border-color: rgba(255, 119, 41, 0.35);
+  --bs-alert-color: #ffb88f;
+}
+.alert-info {
+  --bs-alert-bg: rgba(67, 126, 239, 0.1);
+  --bs-alert-border-color: rgba(67, 126, 239, 0.35);
+  --bs-alert-color: #a9c4fb;
+}
+
+/* ---- Bootstrap utility bg overrides used inside ChatPanel ---- */
+.bg-light { background-color: var(--ch-surface-2) !important; color: var(--ch-text) !important; }
+.bg-light.border { border-color: var(--ch-border) !important; }
+.bg-dark { background-color: #0e0e0d !important; }
+/* user chat bubble: bg-primary text-white would be white-on-yellow — force dark ink */
+.bg-primary { background-color: var(--ch-accent) !important; }
+.bg-primary.text-white { color: #14130f !important; }
+pre.bg-dark.text-light { color: #e6e7e9 !important; border: 1px solid var(--ch-border); font-family: var(--ch-mono); font-size: 0.8rem; }
+
+/* ---- Spinner / loading ---- */
+.spinner-border, .spinner-grow { color: var(--ch-accent); }
+.text-danger { color: var(--ch-red) !important; }
+
+/* ---- MapLibre dark polish ---- */
+.maplibregl-popup-content {
+  background: var(--ch-surface); color: var(--ch-text);
+  border: 1px solid var(--ch-border-strong); border-radius: var(--ch-radius-sm);
+  box-shadow: 0 12px 28px -14px rgba(0, 0, 0, 0.85); font-family: var(--ch-font); font-size: 12px;
+}
+.maplibregl-popup-tip { border-top-color: var(--ch-surface) !important; border-bottom-color: var(--ch-surface) !important; }
+.maplibregl-ctrl-group { background: var(--ch-surface); border: 1px solid var(--ch-border); }
+.maplibregl-ctrl-group button + button { border-top: 1px solid var(--ch-border); }
+.maplibregl-ctrl button .maplibregl-ctrl-icon { filter: invert(0.85); }
+.maplibregl-ctrl-attrib { background: rgba(19, 19, 18, 0.7) !important; }
+.maplibregl-ctrl-attrib a { color: var(--ch-muted); }
+
+/* ---- Scrollbars ---- */
+* { scrollbar-width: thin; scrollbar-color: var(--ch-border-strong) transparent; }
+*::-webkit-scrollbar { width: 10px; height: 10px; }
+*::-webkit-scrollbar-thumb { background: var(--ch-border-strong); border-radius: 6px; border: 2px solid var(--ch-bg); }
+*::-webkit-scrollbar-thumb:hover { background: #53575f; }
+
+/* ---- Error fallback (main.tsx) ---- */
+.app-error { min-height: 60vh; display: grid; place-items: center; padding: 40px; }
+.app-error-card {
+  max-width: 520px; background: var(--ch-surface); border: 1px solid var(--ch-border);
+  border-left: 3px solid var(--ch-red); border-radius: var(--ch-radius); padding: 24px 26px;
+  box-shadow: var(--ch-shadow);
+}
+.app-error-card .title { color: var(--ch-text-strong); font-weight: 650; font-size: 1.1rem; }
+.app-error-card .detail { color: var(--ch-muted); font-family: var(--ch-mono); font-size: 0.82rem; margin-top: 8px; word-break: break-word; }

--- a/workshops/build_workshop/app/frontend/src/ui/EChart.tsx
+++ b/workshops/build_workshop/app/frontend/src/ui/EChart.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useMemo, useRef } from "react";
 import * as echarts from "echarts";
 
+import { clickhouseEChartsTheme } from "./echartsTheme";
+
+// Register the ClickHouse theme once so every chart picks up the dark palette,
+// axis, and tooltip styling without setting colors itself.
+echarts.registerTheme("clickhouse", clickhouseEChartsTheme);
+
 type Props = {
   option: echarts.EChartsOption;
   height?: number;
@@ -13,7 +19,7 @@ export function EChart({ option, height = 320 }: Props) {
 
   useEffect(() => {
     if (!ref.current) return;
-    const chart = echarts.init(ref.current, undefined, { renderer: "canvas" });
+    const chart = echarts.init(ref.current, "clickhouse", { renderer: "canvas" });
     chart.setOption(stableOption, { notMerge: true });
 
     const ro = new ResizeObserver(() => chart.resize());

--- a/workshops/build_workshop/app/frontend/src/ui/HistoricalZoneMap.tsx
+++ b/workshops/build_workshop/app/frontend/src/ui/HistoricalZoneMap.tsx
@@ -4,6 +4,7 @@ import maplibregl from "maplibre-gl";
 
 import { api } from "../api/client";
 import type { HistoricalFilters } from "./HistoricalFilterBar";
+import { applyDarkBasemap, choroplethFill, ZONE_OUTLINE_COLOR } from "./mapTheme";
 
 type Props = { filters: HistoricalFilters };
 
@@ -90,6 +91,8 @@ export function HistoricalZoneMap({ filters }: Props) {
     map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }), "top-right");
 
     map.on("load", () => {
+      applyDarkBasemap(map);
+
       map.addSource("zones", {
         type: "geojson",
         data: choroplethGeojson ?? { type: "FeatureCollection", features: [] }
@@ -100,20 +103,8 @@ export function HistoricalZoneMap({ filters }: Props) {
         type: "fill",
         source: "zones",
         paint: {
-          "fill-color": [
-            "step",
-            ["get", "value"],
-            "#fff7bc",
-            breaks[0],
-            "#fec44f",
-            breaks[1],
-            "#fe9929",
-            breaks[2],
-            "#ec7014",
-            breaks[3],
-            "#cc4c02"
-          ],
-          "fill-opacity": 0.65
+          "fill-color": choroplethFill(breaks),
+          "fill-opacity": 0.8
         }
       });
 
@@ -121,7 +112,7 @@ export function HistoricalZoneMap({ filters }: Props) {
         id: "zones-outline",
         type: "line",
         source: "zones",
-        paint: { "line-color": "#0b1f3a", "line-width": 0.6, "line-opacity": 0.55 }
+        paint: { "line-color": ZONE_OUTLINE_COLOR, "line-width": 0.5, "line-opacity": 0.25 }
       });
 
       map.on("mousemove", "zones-fill", (e) => {
@@ -134,9 +125,9 @@ export function HistoricalZoneMap({ filters }: Props) {
         (map as any).__popup
           .setLngLat(e.lngLat)
           .setHTML(
-            `<div style="font-weight:600">${props.zone ?? "Zone"}</div>
-             <div style="color:#666">${props.borough ?? ""}</div>
-             <div style="margin-top:4px"><span style="color:#666">Value:</span> ${Number(value).toLocaleString()}</div>`
+            `<div style="font-weight:600;color:#fff">${props.zone ?? "Zone"}</div>
+             <div style="color:#9a9ea7">${props.borough ?? ""}</div>
+             <div style="margin-top:4px"><span style="color:#9a9ea7">Value:</span> <span style="color:#faff69">${Number(value).toLocaleString()}</span></div>`
           )
           .addTo(map);
       });
@@ -161,19 +152,7 @@ export function HistoricalZoneMap({ filters }: Props) {
     if (!src || !choroplethGeojson) return;
     src.setData(choroplethGeojson as any);
     if (map.getLayer("zones-fill")) {
-      map.setPaintProperty("zones-fill", "fill-color", [
-        "step",
-        ["get", "value"],
-        "#fff7bc",
-        breaks[0],
-        "#fec44f",
-        breaks[1],
-        "#fe9929",
-        breaks[2],
-        "#ec7014",
-        breaks[3],
-        "#cc4c02"
-      ]);
+      map.setPaintProperty("zones-fill", "fill-color", choroplethFill(breaks));
     }
   }, [choroplethGeojson, breaks]);
 

--- a/workshops/build_workshop/app/frontend/src/ui/SeasonalityHeatmap.tsx
+++ b/workshops/build_workshop/app/frontend/src/ui/SeasonalityHeatmap.tsx
@@ -49,14 +49,14 @@ export function SeasonalityHeatmap({ filters }: Props) {
         orient: "horizontal" as const,
         left: "center",
         bottom: 0,
-        inRange: { color: ["#fff7bc", "#fec44f", "#fe9929", "#ec7014", "#cc4c02"] }
+        inRange: { color: ["#454722", "#7e8a2f", "#b9c53f", "#e4ec55", "#faff69"] }
       },
       series: [
         {
           name: "value",
           type: "heatmap" as const,
           data,
-          emphasis: { itemStyle: { borderColor: "#333", borderWidth: 1 } },
+          emphasis: { itemStyle: { borderColor: "#ffffff", borderWidth: 1 } },
           progressive: 1000
         }
       ]

--- a/workshops/build_workshop/app/frontend/src/ui/ZoneMap.tsx
+++ b/workshops/build_workshop/app/frontend/src/ui/ZoneMap.tsx
@@ -5,6 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { api } from "../api/client";
 import type { Zone } from "../api/types";
 import type { DashboardFilters } from "./FilterBar";
+import { applyDarkBasemap, choroplethFill, ZONE_OUTLINE_COLOR } from "./mapTheme";
 
 type Props = {
   zones: Zone[];
@@ -104,6 +105,8 @@ export function ZoneMap({ zones, filters }: Props) {
     map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }), "top-right");
 
     map.on("load", () => {
+      applyDarkBasemap(map);
+
       map.addSource("zones", {
         type: "geojson",
         data: choroplethGeojson ?? { type: "FeatureCollection", features: [] }
@@ -114,20 +117,8 @@ export function ZoneMap({ zones, filters }: Props) {
         type: "fill",
         source: "zones",
         paint: {
-          "fill-color": [
-            "step",
-            ["get", "value"],
-            "#fff7bc",
-            breaks[0],
-            "#fec44f",
-            breaks[1],
-            "#fe9929",
-            breaks[2],
-            "#ec7014",
-            breaks[3],
-            "#cc4c02"
-          ],
-          "fill-opacity": 0.65
+          "fill-color": choroplethFill(breaks),
+          "fill-opacity": 0.8
         }
       });
 
@@ -135,7 +126,7 @@ export function ZoneMap({ zones, filters }: Props) {
         id: "zones-outline",
         type: "line",
         source: "zones",
-        paint: { "line-color": "#0b1f3a", "line-width": 0.6, "line-opacity": 0.6 }
+        paint: { "line-color": ZONE_OUTLINE_COLOR, "line-width": 0.5, "line-opacity": 0.25 }
       });
 
       map.on("mousemove", "zones-fill", (e) => {
@@ -148,9 +139,9 @@ export function ZoneMap({ zones, filters }: Props) {
         (map as any).__popup
           .setLngLat(e.lngLat)
           .setHTML(
-            `<div style="font-weight:600">${props.zone ?? "Zone"}</div>
-             <div style="color:#666">${props.borough ?? ""}</div>
-             <div style="margin-top:4px"><span style="color:#666">Trips:</span> ${value}</div>`
+            `<div style="font-weight:600;color:#fff">${props.zone ?? "Zone"}</div>
+             <div style="color:#9a9ea7">${props.borough ?? ""}</div>
+             <div style="margin-top:4px"><span style="color:#9a9ea7">Trips:</span> <span style="color:#faff69">${value}</span></div>`
           )
           .addTo(map);
       });
@@ -176,19 +167,7 @@ export function ZoneMap({ zones, filters }: Props) {
     src.setData(choroplethGeojson as any);
 
     if (map.getLayer("zones-fill")) {
-      map.setPaintProperty("zones-fill", "fill-color", [
-        "step",
-        ["get", "value"],
-        "#fff7bc",
-        breaks[0],
-        "#fec44f",
-        breaks[1],
-        "#fe9929",
-        breaks[2],
-        "#ec7014",
-        breaks[3],
-        "#cc4c02"
-      ]);
+      map.setPaintProperty("zones-fill", "fill-color", choroplethFill(breaks));
     }
   }, [choroplethGeojson, breaks]);
 
@@ -196,7 +175,7 @@ export function ZoneMap({ zones, filters }: Props) {
     <div>
       <div ref={ref} style={{ width: "100%", height: 320, borderRadius: 8, overflow: "hidden" }} />
       <div className="text-secondary small mt-2">
-        Choropleth by pickup trips (darker = more trips). {statsQ.data ? `Query ${statsQ.data.meta.elapsed_ms}ms` : ""}
+        Choropleth by pickup trips (brighter = more trips). {statsQ.data ? `Query ${statsQ.data.meta.elapsed_ms}ms` : ""}
         {geojsonError ? <span className="text-danger"> • {geojsonError}</span> : null}
       </div>
     </div>

--- a/workshops/build_workshop/app/frontend/src/ui/echartsTheme.ts
+++ b/workshops/build_workshop/app/frontend/src/ui/echartsTheme.ts
@@ -1,0 +1,80 @@
+// ClickHouse-styled ECharts theme (Click UI dark palette).
+// Registered once in EChart.tsx and applied to every chart, so individual
+// components don't need to set colors, axis, or tooltip styling themselves.
+
+const FONT =
+  'Inter, "SF Pro Display", -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Segoe UI", system-ui, sans-serif';
+
+// Categorical series palette — the Click UI accent colors, brightest first.
+export const CH_CHART_PALETTE = [
+  "#faff69", // ClickHouse yellow
+  "#437eef", // blue
+  "#00cbeb", // cyan
+  "#fb64d6", // magenta
+  "#33ff44", // green
+  "#ff7729", // orange
+  "#bb33ff", // purple
+  "#6df8e1"  // teal
+];
+
+const MUTED = "#9a9ea7";
+const LEGEND = "#b3b6bd";
+const LINE = "#414141";
+const SPLIT = "#282828";
+
+const axis = {
+  axisLine: { show: true, lineStyle: { color: LINE } },
+  axisTick: { show: false, lineStyle: { color: LINE } },
+  axisLabel: { color: MUTED },
+  splitLine: { show: true, lineStyle: { color: SPLIT } },
+  splitArea: { show: false }
+};
+
+export const clickhouseEChartsTheme = {
+  color: CH_CHART_PALETTE,
+  backgroundColor: "transparent",
+  textStyle: { fontFamily: FONT, color: LEGEND },
+
+  title: {
+    textStyle: { color: "#ffffff", fontFamily: FONT, fontWeight: 600 },
+    subtextStyle: { color: MUTED, fontFamily: FONT }
+  },
+
+  legend: { textStyle: { color: LEGEND, fontFamily: FONT }, inactiveColor: "#53575f" },
+
+  tooltip: {
+    backgroundColor: "#1f1f1c",
+    borderColor: "#414141",
+    borderWidth: 1,
+    textStyle: { color: "#e6e7e9", fontFamily: FONT },
+    axisPointer: {
+      lineStyle: { color: "#53575f" },
+      crossStyle: { color: "#53575f" },
+      shadowStyle: { color: "rgba(255,255,255,0.04)" }
+    }
+  },
+
+  grid: { borderColor: LINE, containLabel: true },
+
+  categoryAxis: { ...axis, splitLine: { show: false, lineStyle: { color: SPLIT } } },
+  valueAxis: { ...axis, axisLine: { show: false, lineStyle: { color: LINE } } },
+  logAxis: { ...axis, axisLine: { show: false, lineStyle: { color: LINE } } },
+  timeAxis: { ...axis },
+
+  line: { symbol: "circle", symbolSize: 4, lineStyle: { width: 2 } },
+  bar: { itemStyle: { borderRadius: [3, 3, 0, 0] } },
+
+  visualMap: {
+    textStyle: { color: LEGEND, fontFamily: FONT },
+    inRange: { color: ["#454722", "#7e8a2f", "#b9c53f", "#e4ec55", "#faff69"] }
+  },
+
+  dataZoom: {
+    textStyle: { color: MUTED, fontFamily: FONT },
+    borderColor: "#323232",
+    handleStyle: { color: "#faff69", borderColor: "#faff69" },
+    moveHandleStyle: { color: "#53575f" },
+    fillerColor: "rgba(250,255,105,0.12)",
+    dataBackground: { lineStyle: { color: "#414141" }, areaStyle: { color: "#282828" } }
+  }
+};

--- a/workshops/build_workshop/app/frontend/src/ui/mapTheme.ts
+++ b/workshops/build_workshop/app/frontend/src/ui/mapTheme.ts
@@ -1,0 +1,53 @@
+// Shared ClickHouse map theming for the MapLibre choropleths (ZoneMap +
+// HistoricalZoneMap). Darkens the demo basemap and provides the brand
+// choropleth ramp so both maps stay in sync.
+
+import type maplibregl from "maplibre-gl";
+
+// Dim → bright ClickHouse yellow: higher value = brighter (reads well on dark).
+export const CHOROPLETH_COLORS = ["#454722", "#7e8a2f", "#b9c53f", "#e4ec55", "#faff69"];
+
+// Build a MapLibre "step" fill-color expression from four break points.
+export function choroplethFill(breaks: number[]): any {
+  return [
+    "step",
+    ["get", "value"],
+    CHOROPLETH_COLORS[0],
+    breaks[0],
+    CHOROPLETH_COLORS[1],
+    breaks[1],
+    CHOROPLETH_COLORS[2],
+    breaks[2],
+    CHOROPLETH_COLORS[3],
+    breaks[3],
+    CHOROPLETH_COLORS[4]
+  ];
+}
+
+export const ZONE_OUTLINE_COLOR = "#e6e7e9";
+
+// Recolor the demo basemap's own layers to a dark ClickHouse surface. Call this
+// at the start of the map's "load" handler, before adding the choropleth layers
+// (so those are left untouched). Every setter is guarded so an unexpected demo
+// style can never break the map.
+export function applyDarkBasemap(map: maplibregl.Map): void {
+  try {
+    const layers = map.getStyle()?.layers ?? [];
+    for (const layer of layers) {
+      const id = layer.id;
+      try {
+        if (layer.type === "background") {
+          map.setPaintProperty(id, "background-color", "#131312");
+        } else if (layer.type === "fill") {
+          map.setPaintProperty(id, "fill-color", "#20201d");
+          map.setPaintProperty(id, "fill-outline-color", "#2b2b28");
+        } else if (layer.type === "line") {
+          map.setPaintProperty(id, "line-color", "#2f2f2c");
+        } else if (layer.type === "symbol") {
+          try { map.setPaintProperty(id, "text-color", "#6b6f77"); } catch { /* layer has no text */ }
+          try { map.setPaintProperty(id, "text-halo-color", "#131312"); } catch { /* no halo */ }
+        }
+      } catch { /* skip any layer that rejects the paint override */ }
+    }
+  } catch { /* getStyle unavailable — leave the basemap as-is */ }
+}


### PR DESCRIPTION
## What

Reskins the NYC-taxi workshop app frontend with a ClickHouse **Click UI dark theme**, replacing the stock-Bootstrap default look.

## Changes

- **`src/theme.css`** (new) — Click UI dark tokens mapped onto Bootstrap 5.3 CSS variables, plus a polish layer: app shell/header with the official ClickHouse mark, cards, tables, forms, buttons, alerts, chat panel, MapLibre popups, scrollbars, and a themed error state.
- **`src/ui/echartsTheme.ts`** (new) — registered ECharts theme (ClickHouse categorical palette, dark axes/tooltips), applied to every chart via `EChart.tsx`.
- **`src/ui/mapTheme.ts`** (new) — shared dark basemap + brand choropleth ramp for both MapLibre maps.
- **`App.tsx`** — ClickHouse-branded header (official logo + wordmark), active-state nav tabs, live pulse dot.
- **`main.tsx`** — import the theme, restyled error boundary.
- **`EChart.tsx`** — apply the registered theme.
- **`ZoneMap.tsx` / `HistoricalZoneMap.tsx`** — dark basemap, brand choropleth, readable dark popups.
- **`SeasonalityHeatmap.tsx`** — brand color ramp.
- **`index.html`** — `data-bs-theme="dark"`, Inter font, updated title.

Presentation-only — no API/data/logic changes.

## Verification

- `tsc -b && vite build` passes clean.
- Verified end to end against a live ClickHouse Cloud service (real data): dashboards, charts, tables, forms, chat, and both MapLibre choropleths render correctly in the dark theme.

## Notes

- The learner playbook screenshots of this UI will be refreshed separately.
- Module 07 fault branches (`fault/01`, `fault/03`) touch `ZoneMap`/`HistoricalZoneMap`; changes here are presentational, so fault behavior is unaffected — just merge mechanics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
