### PR TITLE
ci(workshop): retire main deployment trigger

### DIFF
--- a/.github/workflows/workshop.yml
+++ b/.github/workflows/workshop.yml
@@ -1,12 +1,17 @@
 name: Workshop
 
+# dev-build-workshop-v1 deploys dev; build-workshop-v1 deploys production.
+
 on:
   pull_request:
-    branches: [dev, main]
+    # Keep the required workshop check available on the existing protected repo
+    # branches, but only the dedicated workshop branches deploy on push.
+    branches: [dev, main, dev-build-workshop-v1, build-workshop-v1]
   push:
-    branches: [dev, main]
+    branches: [dev-build-workshop-v1, build-workshop-v1]
     paths:
       - "workshops/build_workshop/**"
+      - ".github/workflows/workshop.yml"
   workflow_dispatch: {}
 
 concurrency:
@@ -71,7 +76,8 @@ jobs:
     name: Deploy workshop
     if: >-
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
-      (github.ref_name == 'dev' || github.ref_name == 'main')
+      (github.ref_name == 'dev-build-workshop-v1' ||
+       github.ref_name == 'build-workshop-v1')
     needs: verify
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -88,7 +94,7 @@ jobs:
           PROD_INSTANCE_ID: ${{ vars.WORKSHOP_PROD_INSTANCE_ID }}
         run: |
           set -euo pipefail
-          if [[ "${GITHUB_REF_NAME}" == "main" ]]; then
+          if [[ "${GITHUB_REF_NAME}" == "build-workshop-v1" ]]; then
             echo "instance_id=${PROD_INSTANCE_ID}" >> "${GITHUB_OUTPUT}"
             echo "image_alias=prod" >> "${GITHUB_OUTPUT}"
             echo "url=https://workshop.demohouse.cloud" >> "${GITHUB_OUTPUT}"

--- a/workshops/build_workshop/README.md
+++ b/workshops/build_workshop/README.md
@@ -6,9 +6,11 @@ with ClickPipes, conversational BI with ClickHouse Agents, observability with Cl
 (including an AI-built SRE dashboard), a break-and-fix incident lab diagnosed by an AI
 SRE, and an in-app AI chat traced to Langfuse Cloud.
 
-Learners clone `main`. Maintainers create a feature branch, open a PR to protected `dev`,
-verify [dev-workshop.demohouse.cloud](https://dev-workshop.demohouse.cloud), then promote
-`dev` to protected `main` for [workshop.demohouse.cloud](https://workshop.demohouse.cloud).
+Learners clone the repository, then switch to `build-workshop-v1`. Maintainers create a
+feature branch, open a PR to protected `dev-build-workshop-v1`, verify
+[dev-workshop.demohouse.cloud](https://dev-workshop.demohouse.cloud), then promote
+`dev-build-workshop-v1` to protected `build-workshop-v1` for
+[workshop.demohouse.cloud](https://workshop.demohouse.cloud).
 
 ## Architecture
 
@@ -80,7 +82,7 @@ flowchart LR
   M07 -.->|pick one or more| F["fault/01-map-not-loading<br/>fault/02-zone-stats-500<br/>fault/03-slow-dashboard"]
 ```
 
-Every module except 07 stays on `main`; the only branch switches are the
+Every module except 07 stays on `build-workshop-v1`; the only branch switches are the
 fault branches in module 07.
 
 ### How a trip row flows (live CDC path)
@@ -111,7 +113,7 @@ flowchart LR
   OTEL --> HDX2["HyperDX UI<br/>search, traces, dashboards"]
   SRE["coding agent via ClickStack MCP<br/>clickstack_search, save_dashboard,<br/>save_alert"] -.-> OTEL
   FAULT["module 07: git checkout fault/*<br/>a realistic bug ships"] --> APP
-  SRE -->|diagnose from telemetry| FIX["apply the fix,<br/>return to main"]
+  SRE -->|diagnose from telemetry| FIX["apply the fix,<br/>return to build-workshop-v1"]
 ```
 
 ## Layout
@@ -125,7 +127,7 @@ flowchart LR
 
 ## Fault branches (module 07, break and fix)
 
-Kept current with `main`, each differs from the base by one innocent-looking
+Kept current with `build-workshop-v1`, each differs from the base by one innocent-looking
 change touching one file under `app/`:
 
 - `fault/01-map-not-loading`
@@ -139,8 +141,10 @@ deliberately not documented in this directory.
 ## Quick start (participant)
 
 ```bash
-git clone -b main <this-repo>
-cd ClickHouse_Demos/workshops/build_workshop/app
+git clone <this-repo>
+cd ClickHouse_Demos
+git switch build-workshop-v1
+cd workshops/build_workshop/app
 cp .env.workshop.example .env.workshop   # fill in your ClickHouse Cloud values
 ./preflight.sh                           # must print "Overall: READY"
 docker compose --env-file .env.workshop -f docker-compose.workshop.yml up -d

--- a/workshops/build_workshop/playbook/README.md
+++ b/workshops/build_workshop/playbook/README.md
@@ -6,7 +6,7 @@ an NYC-taxi ride-hailing analytics app end to end on ClickHouse Cloud.
 
 This directory is the documentation site only. The workshop app that participants clone
 and build on lives alongside it at `workshops/build_workshop/app` in this repository, on
-the `main` branch. The site is built with [Next.js](https://nextjs.org)
+the `build-workshop-v1` branch. The site is built with [Next.js](https://nextjs.org)
 and [Fumadocs](https://fumadocs.dev). Production is
 [workshop.demohouse.cloud](https://workshop.demohouse.cloud); dev is
 [dev-workshop.demohouse.cloud](https://dev-workshop.demohouse.cloud).
@@ -49,9 +49,9 @@ npm run build -- --webpack
 
 Promotion is branch-based:
 
-1. Create a feature branch and PR it to protected `dev`.
+1. Create a feature branch and PR it to protected `dev-build-workshop-v1`.
 2. Required workshop CI passes; merging deploys that SHA to the dev hostname.
-3. Test dev, then open a `dev` to `main` PR.
+3. Test dev, then open a `dev-build-workshop-v1` to `build-workshop-v1` PR.
 4. Merging deploys the same source revision to the production hostname.
 
 The public workflow uses GitHub OIDC, ECR immutable SHA tags, SSM, container health, and
@@ -110,11 +110,11 @@ Every instructor module page has these four sections: `## Timing`, `## Talk trac
 `## Common failures`, `## Reset steps`. Content is filled in from rehearsal; unknowns are
 marked `TODO`.
 
-### Checkpoint branch convention
+### Learner branch convention
 
-The workshop app repository uses `checkpoint/NN-name` branches (for example
-`checkpoint/03-realtime-cdc`) as the starting state for each module; `main` is the
-complete reference. Learner pages reference these branches in their "Starting point".
+Learners clone the repository's default branch, then Module 00 switches them to
+`build-workshop-v1`, the complete workshop reference. They stay there except while
+running a Module 07 `fault/*` scenario, then switch back to `build-workshop-v1`.
 
 ## Project layout
 

--- a/workshops/build_workshop/playbook/content/docs/index.mdx
+++ b/workshops/build_workshop/playbook/content/docs/index.mdx
@@ -111,22 +111,22 @@ The diagrams above are generated from `workshops/build_workshop/docs/diagrams/ge
 
 ## Modules
 
-Ten modules, in order. The app is complete on `main`, so every module except
+Ten modules, in order. The app is complete on `build-workshop-v1`, so every module except
 07 needs no per-module checkout — you configure and connect services rather than change
 app code. The only branch switches are the fault branches in module 07.
 
 | Step | Time | Learner lesson | Instructor notes | Branch | What you will learn |
 |---|---|---|---|---|---|
-| 00 | 25 min | [Setup](/docs/learner/00-setup) | [notes](/docs/instructor/00-setup) | `main` | Accounts, tools, agent skills, and the app repo, all wired up and verified |
-| 01 | 15 min | [ClickHouse Cloud](/docs/learner/01-clickhouse-cloud) | [notes](/docs/instructor/01-clickhouse-cloud) | `main` | Create the schema, seed historical data from object storage, and feel the query speed |
-| 02 | 5 min | [Base app](/docs/learner/02-base-app) | [notes](/docs/instructor/02-base-app) | `main` | Tour the running app now that it has data: Ops and Historical dashboards, the chat panel, the data flow |
-| 03 | 20 min | [Real-time CDC](/docs/learner/03-realtime-cdc) | [notes](/docs/instructor/03-realtime-cdc) | `main` | Stream live rows from managed Postgres into ClickHouse with a Postgres CDC ClickPipe |
-| 04 | 10 min | [ClickHouse Agents](/docs/learner/04-clickhouse-agents) | [notes](/docs/instructor/04-clickhouse-agents) | `main` | Conversational BI: create an agent over your taxi data and explore it in natural language |
-| 05 | 15 min | [ClickStack](/docs/learner/05-clickstack) | [notes](/docs/instructor/05-clickstack) | `main` | Enable ClickStack and send app traces and logs to HyperDX |
-| 06 | 15 min | [AI SRE](/docs/learner/06-ai-sre) | [notes](/docs/instructor/06-ai-sre) | `main` | Use the ClickStack MCP connection to build an SRE dashboard and alert |
+| 00 | 25 min | [Setup](/docs/learner/00-setup) | [notes](/docs/instructor/00-setup) | `build-workshop-v1` | Accounts, tools, agent skills, and the app repo, all wired up and verified |
+| 01 | 15 min | [ClickHouse Cloud](/docs/learner/01-clickhouse-cloud) | [notes](/docs/instructor/01-clickhouse-cloud) | `build-workshop-v1` | Create the schema, seed historical data from object storage, and feel the query speed |
+| 02 | 5 min | [Base app](/docs/learner/02-base-app) | [notes](/docs/instructor/02-base-app) | `build-workshop-v1` | Tour the running app now that it has data: Ops and Historical dashboards, the chat panel, the data flow |
+| 03 | 20 min | [Real-time CDC](/docs/learner/03-realtime-cdc) | [notes](/docs/instructor/03-realtime-cdc) | `build-workshop-v1` | Stream live rows from managed Postgres into ClickHouse with a Postgres CDC ClickPipe |
+| 04 | 10 min | [ClickHouse Agents](/docs/learner/04-clickhouse-agents) | [notes](/docs/instructor/04-clickhouse-agents) | `build-workshop-v1` | Conversational BI: create an agent over your taxi data and explore it in natural language |
+| 05 | 15 min | [ClickStack](/docs/learner/05-clickstack) | [notes](/docs/instructor/05-clickstack) | `build-workshop-v1` | Enable ClickStack and send app traces and logs to HyperDX |
+| 06 | 15 min | [AI SRE](/docs/learner/06-ai-sre) | [notes](/docs/instructor/06-ai-sre) | `build-workshop-v1` | Use the ClickStack MCP connection to build an SRE dashboard and alert |
 | 07 | 20 min | [Test, fail, and fix](/docs/learner/07-break-and-fix) | [notes](/docs/instructor/07-break-and-fix) | `fault/*` | Continue from AI SRE or optional 06b, inject a fault, diagnose it, fix it, and prove recovery |
-| 08 | 15 min | [Chat and Langfuse](/docs/learner/08-chat-langfuse) | [notes](/docs/instructor/08-chat-langfuse) | `main` | Use the in-app AI chat and follow its traces, generations, and costs in Langfuse |
-| 09 | 10 min | [Wrap-up](/docs/learner/09-wrap-up) | [notes](/docs/instructor/09-wrap-up) | `main` | Review what you built, take it home, and extend it to your own data |
+| 08 | 15 min | [Chat and Langfuse](/docs/learner/08-chat-langfuse) | [notes](/docs/instructor/08-chat-langfuse) | `build-workshop-v1` | Use the in-app AI chat and follow its traces, generations, and costs in Langfuse |
+| 09 | 10 min | [Wrap-up](/docs/learner/09-wrap-up) | [notes](/docs/instructor/09-wrap-up) | `build-workshop-v1` | Review what you built, take it home, and extend it to your own data |
 
 The times add up to about 2 hours 30 minutes of hands-on work; the rest of the
 three-hour session is the opening, transitions, and the finale demos.
@@ -135,19 +135,19 @@ three-hour session is the opening, transitions, and the finale demos.
 
 ### Branches
 
-The app is already complete on `main`. This workshop is about configuring and connecting
-services — real-time CDC, observability, agents, chat — not editing application code, so
-there is nothing to build up branch by branch:
+The app is already complete on `build-workshop-v1`. This workshop is about configuring
+and connecting services — real-time CDC, observability, agents, chat — not editing
+application code, so there is nothing to build up branch by branch:
 
-- Clone the app once in module 00 and stay on `main` except while running
-  the fault scenarios in module 07.
+- Clone the app once in module 00, switch to `build-workshop-v1`, and stay there except
+  while running the fault scenarios in module 07.
 - Late joiners are never stranded: everything is service-side, so you only need your
   `.env.workshop` filled in plus the module's console steps. There is no per-module
   checkout to catch up on.
 - The only branch switches are in module 07 (Break and fix), which uses fault branches
   (`fault/01-map-not-loading`, `fault/02-zone-stats-500`, `fault/03-slow-dashboard`). You
   check one out, diagnose the failure, then preserve the fix and return to
-  `main` with the module 07 stash-and-switch reset.
+  `build-workshop-v1` with the module 07 stash-and-switch reset.
 
 <Callout title="Fault branches">
   The three `fault/*` branches above exist in the repo; module 07 walks through checking
@@ -190,7 +190,7 @@ Never commit your filled-in `.env.workshop`; it is git-ignored.
 ## Repository layout
 
 Everything lives in one repository (`ClickHouse_Demos`), under
-`workshops/build_workshop/`, on the `main` branch.
+`workshops/build_workshop/`, on the `build-workshop-v1` branch.
 
 ```text
 workshops/build_workshop/

--- a/workshops/build_workshop/playbook/content/docs/instructor/07-break-and-fix.mdx
+++ b/workshops/build_workshop/playbook/content/docs/instructor/07-break-and-fix.mdx
@@ -28,7 +28,8 @@ so the wrap-up is not squeezed.
 ## Answer key
 
 Do not share this section with learners; it lives in the playbook only and is never
-committed to the app repo. Each fault is one small change on its own branch off `main`;
+committed to the app repo. Each fault is one small change on its own branch off
+`build-workshop-v1`;
 the fix is to revert it. Run one fault at a time. The lab's incident is fault 01 (5-15 min,
 curveball — the backend is innocent). Optional extras for a fast room: fault 02 (5-10 min,
 warm-up, the trace tells all) and fault 03 only when the full dataset is available
@@ -39,7 +40,7 @@ branch switch):
 
 ```bash
 git stash push --include-untracked -m "module-07-fix"
-git switch main
+git switch build-workshop-v1
 docker compose --env-file .env.workshop \
   -f docker-compose.workshop.yml -f docker-compose.otel.yml up -d --build
 ```

--- a/workshops/build_workshop/playbook/content/docs/learner/00-setup.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/00-setup.mdx
@@ -32,17 +32,25 @@ python3 --version
   ask your administrator if the OAuth step in Step 7 cannot open.
 </Callout>
 
-## Step 2 — Clone `main` and enter the app directory
+## Step 2 — Clone the repo and switch to the workshop branch
 
 ```bash
-git clone --branch main https://github.com/ClickHouse/ClickHouse_Demos.git
-cd ClickHouse_Demos/workshops/build_workshop/app
+git clone https://github.com/ClickHouse/ClickHouse_Demos.git
+cd ClickHouse_Demos
+git switch build-workshop-v1
+cd workshops/build_workshop/app
 cp .env.workshop.example .env.workshop
 ```
 
 Keep this terminal in `ClickHouse_Demos/workshops/build_workshop/app`. The preflight script
-is `./preflight.sh` **inside this directory**. Stay on `main` except during Module 07 fault
-tests.
+is `./preflight.sh` **inside this directory**. Stay on `build-workshop-v1` except during
+Module 07 fault tests. Confirm the branch now:
+
+```bash
+git branch --show-current
+```
+
+Expected: `build-workshop-v1`.
 
 ## Step 3 — Create a ClickHouse Cloud account and API key
 

--- a/workshops/build_workshop/playbook/content/docs/learner/02-base-app.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/02-base-app.mdx
@@ -5,7 +5,8 @@ description: Tour the running NYC-taxi app, now that ClickHouse is seeded, so yo
 
 ## Starting point
 
-You are on `main` (cloned in module 00) — no checkout needed. Budget about **5 minutes**.
+You are on `build-workshop-v1` (selected in Module 00) — no checkout needed. Budget
+about **5 minutes**.
 The workshop stack you started in module 00 should still be running.
 
 Prerequisites: modules 00 and 01 complete (the stack healthy, ClickHouse seeded), the

--- a/workshops/build_workshop/playbook/content/docs/learner/04-clickhouse-agents.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/04-clickhouse-agents.mdx
@@ -5,8 +5,8 @@ description: Create a ClickHouse Agent over your taxi data and explore it conver
 
 ## Starting point
 
-You are on `main` — no checkout needed. Budget about **10 minutes**. This module is
-entirely in the ClickHouse Cloud console; there is nothing to run locally.
+You are on `build-workshop-v1` — no checkout needed. Budget about **10 minutes**. This
+module is entirely in the ClickHouse Cloud console; there is nothing to run locally.
 
 Prerequisites: modules 01 and 03 complete (seeded history plus a live CDC stream in your
 Cloud service).

--- a/workshops/build_workshop/playbook/content/docs/learner/05-clickstack.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/05-clickstack.mdx
@@ -5,9 +5,9 @@ description: Enable ClickStack, run the local OpenTelemetry collector overlay, a
 
 ## Starting point
 
-You are on `main` — no checkout needed. Budget about **15 minutes**. The app is already
-instrumented for OpenTelemetry on `main`; in this module you turn it on with the collector
-overlay.
+You are on `build-workshop-v1` — no checkout needed. Budget about **15 minutes**. The app
+is already instrumented for OpenTelemetry; in this module you turn it on with the
+collector overlay.
 
 Prerequisites: your Cloud service running (module 01).
 

--- a/workshops/build_workshop/playbook/content/docs/learner/06-ai-sre.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/06-ai-sre.mdx
@@ -5,7 +5,7 @@ description: Connect your coding agent to the ClickStack MCP and have it build a
 
 ## Starting point
 
-You are on `main` — no checkout needed. Budget about **15 minutes**.
+You are on `build-workshop-v1` — no checkout needed. Budget about **15 minutes**.
 
 Prerequisites: telemetry flowing into ClickStack (module 05), your coding agent working
 with MCP support (module 00).

--- a/workshops/build_workshop/playbook/content/docs/learner/06b-ai-sre-librechat.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/06b-ai-sre-librechat.mdx
@@ -5,7 +5,7 @@ description: Optional — run a prebuilt LibreChat SRE agent that investigates t
 
 ## Starting point
 
-Optional module. You are on `main` — no checkout needed yet. Budget about
+Optional module. You are on `build-workshop-v1` — no checkout needed yet. Budget about
 **20 minutes**.
 
 Prerequisites: module 05 complete (telemetry flowing into ClickStack), the workshop repo

--- a/workshops/build_workshop/playbook/content/docs/learner/07-break-and-fix.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/07-break-and-fix.mdx
@@ -27,7 +27,7 @@ The following example injects Fault 01 while preserving any local work:
 ```bash
 cd "$(git rev-parse --show-toplevel)"
 git stash push --include-untracked -m "before-module-07"
-git switch main
+git switch build-workshop-v1
 git switch fault/01-map-not-loading
 
 cd workshops/build_workshop/app
@@ -86,12 +86,12 @@ timestamps instead of expecting history to disappear.
 
 ## Step 5 — Return to the clean baseline
 
-Preserve your attempted fix, restore `main`, and rebuild both app services:
+Preserve your attempted fix, restore `build-workshop-v1`, and rebuild both app services:
 
 ```bash
 cd "$(git rev-parse --show-toplevel)"
 git stash push --include-untracked -m "module-07-fix"
-git switch main
+git switch build-workshop-v1
 
 cd workshops/build_workshop/app
 docker compose --env-file .env.workshop \
@@ -106,6 +106,6 @@ docker compose --env-file .env.workshop \
 - The agent cited telemetry that proves the root cause.
 - The same recovery check passes after the fix.
 - A fresh session creates no new matching error.
-- `git branch --show-current` returns `main`.
+- `git branch --show-current` returns `build-workshop-v1`.
 
 Continue to [08 Chat and Langfuse](/docs/learner/08-chat-langfuse).

--- a/workshops/build_workshop/playbook/content/docs/learner/08-chat-langfuse.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/08-chat-langfuse.mdx
@@ -7,7 +7,7 @@ description: Run the in-app AI chat and verify its trace, tokens, latency, and c
 
 In about **15 minutes**, the app will answer a data question and Langfuse will show the
 complete model trace. Start only after Module 07 is recovered and
-`git branch --show-current` returns `main`.
+`git branch --show-current` returns `build-workshop-v1`.
 
 ## Step 1 — Verify the keys
 

--- a/workshops/build_workshop/playbook/content/docs/learner/09-wrap-up.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/09-wrap-up.mdx
@@ -5,9 +5,9 @@ description: Review what you built, take it home, and learn how to extend it to 
 
 ## Starting point
 
-You are on `main` — the complete app you have been configuring all session. If you
-checked out a fault branch in module 07, use that module's stash-and-switch reset before continuing.
-Budget about **10 minutes**.
+You are on `build-workshop-v1` — the complete app you have been configuring all session.
+If you checked out a fault branch in module 07, use that module's stash-and-switch reset
+before continuing. Budget about **10 minutes**.
 
 ## Why
 
@@ -96,8 +96,7 @@ further, pick any of these:
   module — it names the exact expected output.
 - Setup or credential issues? [Troubleshooting](/docs/learner/troubleshooting) lists every
   failure seen in testing with its fix.
-- Want a clean slate? Each module names a checkpoint branch, and `git checkout
-  main` returns you to the complete app.
+- Want a clean baseline? `git switch build-workshop-v1` returns you to the complete app.
 
 ## End state
 

--- a/workshops/build_workshop/playbook/src/lib/shared.ts
+++ b/workshops/build_workshop/playbook/src/lib/shared.ts
@@ -5,11 +5,11 @@ export const docsContentRoute = '/llms.mdx/docs';
 
 // GitHub info for the "Edit on GitHub" links and the nav GitHub button.
 // The playbook lives in the ClickHouse_Demos monorepo under
-// workshops/build_workshop/playbook on the main branch.
+// workshops/build_workshop/playbook on the production workshop branch.
 export const gitConfig = {
   user: 'ClickHouse',
   repo: 'ClickHouse_Demos',
-  branch: 'main',
+  branch: 'build-workshop-v1',
 };
 
 // The repo participants clone; the app lives at workshops/build_workshop/app.

--- a/workshops/build_workshop/scripts/check-docs.sh
+++ b/workshops/build_workshop/scripts/check-docs.sh
@@ -15,8 +15,8 @@ fail_if_found() {
 }
 
 fail_if_found \
-  "active workshop docs must use the dev/main promotion model" \
-  'build-workshop-v1' \
+  "active workshop docs must not use the retired dev/main promotion commands" \
+  'git switch main|git clone[^[:cntrl:]]*--branch main|`dev` to (protected )?`main`|PR it to protected `dev`' \
   "${ROOT}/README.md" "${CONTENT}"
 
 fail_if_found \
@@ -38,6 +38,16 @@ require_fixed() {
     exit 1
   fi
 }
+
+require_fixed \
+  "maintainer docs must name the workshop staging branch" \
+  'dev-build-workshop-v1' \
+  "${ROOT}/README.md"
+
+require_fixed \
+  "learner setup must switch to the production workshop branch" \
+  'git switch build-workshop-v1' \
+  "${CONTENT}/learner/00-setup.mdx"
 
 require_count() {
   local description=$1


### PR DESCRIPTION
## Summary

- keep Workshop CI available for PRs to the protected repository branches
- stop `dev` and `main` pushes from entering the workshop deploy job
- document `feature/*` to `dev-build-workshop-v1` to `build-workshop-v1` promotion
- point learner setup, fault recovery, and edit links at `build-workshop-v1`

The new dedicated branches are already deployed and protected. The IAM deploy role also trusts only those two branches, so this PR removes the obsolete workflow trigger rather than changing a live target.

## Verification

- workshop documentation policy passed
- all workshop shell scripts passed syntax validation
- the same commit passed full CI and deployed successfully from both dedicated branches
