### PR TITLE
feat(workshop): add Windows WSL learner track

### DIFF
--- a/.github/workflows/workshop.yml
+++ b/.github/workflows/workshop.yml
@@ -72,13 +72,69 @@ jobs:
           NEXT_TELEMETRY_DISABLED: "1"
         run: npm run build -- --webpack
 
+  windows:
+    name: Windows compatibility
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: workshops/build_workshop
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate Windows and WSL documentation contract
+        shell: pwsh
+        run: ./scripts/check-windows.ps1
+
+      - name: Validate Bash scripts after Windows checkout
+        shell: bash
+        run: |
+          find . -type f \( -name '*.sh' -o -name '*.bash' \) -print0 \
+            | xargs -0 -n1 bash -n
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            workshops/build_workshop/app/backend/requirements.txt
+            workshops/build_workshop/app/backend/requirements-dev.txt
+
+      - name: Run backend tests on Windows
+        working-directory: workshops/build_workshop/app/backend
+        shell: pwsh
+        run: |
+          python -m pip install -r requirements-dev.txt
+          python -m pytest tests/test_chat_guardrails.py tests/test_db_retry.py -q
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.12.0"
+          cache: npm
+          cache-dependency-path: workshops/build_workshop/playbook/package-lock.json
+
+      - name: Install playbook dependencies on Windows
+        working-directory: workshops/build_workshop/playbook
+        run: npm ci
+
+      - name: Check playbook types on Windows
+        working-directory: workshops/build_workshop/playbook
+        run: npm run types:check
+
+      - name: Build root-path playbook on Windows
+        working-directory: workshops/build_workshop/playbook
+        env:
+          NEXT_PUBLIC_BASE_PATH: ""
+          NEXT_PUBLIC_SITE_URL: https://workshop.demohouse.cloud
+          NEXT_TELEMETRY_DISABLED: "1"
+        run: npm run build -- --webpack
+
   deploy:
     name: Deploy workshop
     if: >-
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       (github.ref_name == 'dev-build-workshop-v1' ||
        github.ref_name == 'build-workshop-v1')
-    needs: verify
+    needs: [verify, windows]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/workshops/build_workshop/.gitattributes
+++ b/workshops/build_workshop/.gitattributes
@@ -1,0 +1,4 @@
+*.sh text eol=lf
+*.bash text eol=lf
+*.mdx text eol=lf
+*.ps1 text eol=crlf

--- a/workshops/build_workshop/playbook/README.md
+++ b/workshops/build_workshop/playbook/README.md
@@ -89,6 +89,21 @@ content/docs/
   imports are needed for these.
 - No emojis anywhere, in content or code.
 
+### Platform contract
+
+The learner track supports macOS and Windows. Windows means Ubuntu on WSL 2 with Docker
+Desktop WSL integration; it does not mean translating shared Bash blocks into PowerShell.
+
+- Put Windows host bootstrap or repair commands in a `powershell` fence inside
+  `<PlatformOnly platform="windows">`.
+- Keep all workshop, Docker, Git, `clickhousectl`, ClickHouse client, and preflight commands
+  in `bash` fences. Windows learners run them in Ubuntu.
+- Put platform-specific macOS text inside `<PlatformOnly platform="macos">` when the
+  Windows path differs.
+- Never tell Windows learners to clone under `/mnt/c`; use their WSL home directory.
+- Keep shell scripts LF-only. The Windows CI job enforces the platform contract and builds
+  the complete playbook on a Windows runner.
+
 ### The per-module learner contract
 
 Every learner module page follows this skeleton, in order:

--- a/workshops/build_workshop/playbook/content/docs/index.mdx
+++ b/workshops/build_workshop/playbook/content/docs/index.mdx
@@ -11,6 +11,10 @@ managed Postgres, conversational BI over your data, full observability, an AI-as
 SRE workflow, and an in-app AI chat traced end to end, and you will have practiced
 diagnosing a live incident with an AI SRE.
 
+The same workshop supports **macOS** and **Windows**. Choose your computer in the page
+header once; the playbook keeps the correct setup visible everywhere. Windows runs the
+shared workshop toolchain inside Ubuntu on WSL 2.
+
 You leave with a running prototype and this repo to show your team. Your ClickHouse Cloud
 trial keeps running for 30 days after the session, everything you built keeps running on
 it, and the repository is yours to keep. By the end you can demo five things live:

--- a/workshops/build_workshop/playbook/content/docs/instructor/00-setup.mdx
+++ b/workshops/build_workshop/playbook/content/docs/instructor/00-setup.mdx
@@ -12,6 +12,10 @@ up`) before or during the opening talk so they run underneath it. Push attendees
 the three account signups (ClickHouse Cloud, Langfuse, OpenAI) before the day - each is 5
 to 10 minutes - so this module stays inside budget.
 
+For mixed rooms, budget another 10 minutes before the session for Windows learners who
+have not yet installed WSL 2 and Docker Desktop. A restart can be required after
+`wsl --install`.
+
 ## Talk track
 
 - Frame the session: they will move an existing app onto ClickHouse Cloud, and the agent
@@ -22,6 +26,11 @@ to 10 minutes - so this module stays inside budget.
   is front-loaded here; module 01 just builds the schema on the service that already
   exists.
 - Step 7 is the only agent-integration setup: skills, ClickHouse MCP, and ClickStack MCP.
+- Have learners select macOS or Windows in the page header before Step 1. On Windows,
+  PowerShell is only for WSL bootstrap; every workshop command runs in Ubuntu.
+- Treat WSL 2 as Windows prework, not an in-session install. Confirm a supported Windows
+  build, local administrator rights, virtualization, 16 GB host RAM, 20 GB free disk,
+  Ubuntu version 2, and Docker Desktop's Ubuntu integration before doors open.
 
 ## Common failures
 
@@ -30,6 +39,15 @@ to 10 minutes - so this module stays inside budget.
 - Coding agent cannot add MCP servers due to corporate policy (surfaced by the prework
   smoke test).
 - `docker compose up` fails because Docker is under-allocated (needs 6 GB+).
+- Windows learner cloned under `/mnt/c`, causing slow bind mounts or CRLF failures. Re-clone
+  under `~/ClickHouse_Demos` inside Ubuntu and set `git config --global core.autocrlf input`.
+- Docker Desktop runs but Ubuntu cannot reach it. Enable the WSL 2 engine and the explicit
+  Ubuntu integration, then run `wsl --shutdown` from PowerShell.
+- The coding agent opens a separate `C:\Users` checkout while commands run in WSL. Reopen
+  the `~/ClickHouse_Demos` WSL folder in the desktop agent and confirm its terminal reports
+  Linux with `uname -s`.
+- Corporate policy blocks WSL, virtualization, Docker Desktop, or OAuth. This cannot be
+  repaired during the module; move the learner to a prepared loaner or personal machine.
 - The first request after a Cloud service idle-scales to zero used to 500; the back end
   now retries the idle-wake on connect, so the first dashboard load may pause a few seconds
   but succeeds. Not a failure to chase. Confirmed in the 2026-07 clean-room dry run.
@@ -39,4 +57,7 @@ to 10 minutes - so this module stays inside budget.
 - Point a stuck attendee at the loaner Cloud service pool if their trial is unusable.
 - Re-run `cp .env.workshop.example .env.workshop` and re-fill; confirm no stray committed
   `.env.workshop`.
+- On Windows, verify `wsl --status`, `wsl --version`, and `wsl --list --verbose`; Ubuntu
+  must be version 2. Inside Ubuntu, `pwd` starts with `/home/` and `docker version` shows
+  both Client and Server.
 - TODO: confirm reset commands.

--- a/workshops/build_workshop/playbook/content/docs/instructor/index.mdx
+++ b/workshops/build_workshop/playbook/content/docs/instructor/index.mdx
@@ -8,6 +8,10 @@ a matching notes page here with four sections: **Timing**, **Talk track**,
 **Common failures**, and **Reset steps**. Read this landing page first for the
 room-level picture.
 
+The learner path supports macOS and Windows. Windows uses Ubuntu on WSL 2 with Docker
+Desktop integration. Ask everyone to choose their computer in the page header before the
+setup clinic, and keep Windows learners in the Ubuntu terminal after bootstrap.
+
 The learner track also carries a [Running this workshop self-paced](/docs/learner/self-paced)
 page for people doing the workshop with no instructor; it sends them to these notes as
 their answer key (and to the module 07 fault answer key only as a last resort), so keep
@@ -53,6 +57,8 @@ before doors open:
 - **Runtime LLM key pool** — spend-capped fallback keys for the in-app chat (module 08).
 - **Projector and shared channel** — for the finale demos.
 - **Venue network** — enough symmetric bandwidth, no captive portal, OAuth-friendly.
+- **Mixed-platform rehearsal** — one clean macOS run and one clean Windows/WSL 2 run,
+  including Docker integration, MCP browser OAuth, preflight, and Module 07 branch resets.
 
 ## Setup clinic
 

--- a/workshops/build_workshop/playbook/content/docs/learner/00-setup.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/00-setup.mdx
@@ -3,6 +3,10 @@ title: 00 Setup
 description: Create the workshop services, install the CLIs, connect your agent once, and start the local app.
 ---
 
+Choose **macOS** or **Windows** in the page header before you begin. Your choice persists
+across the workshop. Windows uses Ubuntu on WSL 2 so the same Bash, Docker, ClickHouse,
+and agent commands work in every module.
+
 ## Outcome
 
 In about **25 minutes** you will have:
@@ -13,19 +17,112 @@ In about **25 minutes** you will have:
 - Langfuse and OpenAI keys; and
 - the app healthy at [localhost:8080](http://localhost:8080).
 
-Run every command in this module from the app directory unless a step says otherwise.
+After Step 2, run every command from the app directory unless a step says otherwise.
 
 ## Step 1 — Check prerequisites
 
 You need Docker with at least 6 GB of memory, Git, Node.js 20+, Python 3, and one MCP-capable
 coding agent: Claude Code, Cursor, Codex CLI, or Windsurf.
 
+<PlatformOnly platform="macos">
+
+**macOS setup**
+
+Install [Docker Desktop for Mac](https://docs.docker.com/desktop/setup/install/mac-install/)
+and allocate at least 6 GB in **Settings -> Resources**. Open Terminal and run:
+
 ```bash
 docker version
+docker compose version
 git --version
 node --version
 python3 --version
 ```
+
+Continue only when every command prints a version and `docker version` shows both a
+Client and Server section.
+
+</PlatformOnly>
+
+<PlatformOnly platform="windows">
+
+**Windows setup**
+
+The workshop requires **Ubuntu on WSL 2**. Native PowerShell, Command Prompt, Git Bash,
+and WSL 1 are not supported workshop shells. PowerShell is used only to install and
+inspect WSL; all later command blocks run in the Ubuntu terminal.
+
+<Callout type="warn" title="Windows prerequisites — check these before the workshop">
+
+- Windows 11, or Windows 10 version 2004 (build 19041) or later;
+- an account allowed to run PowerShell as Administrator and install Docker Desktop;
+- hardware virtualization enabled in the BIOS/UEFI;
+- 16 GB of host RAM recommended, with at least 6 GB available to WSL and Docker;
+- at least 20 GB of free disk space; and
+- permission from your administrator to use WSL 2, Docker Desktop, and browser OAuth on
+  a managed corporate machine.
+
+Installing WSL may require a Windows restart. Complete this before a live session. If
+corporate policy blocks any item, use a personal machine or ask your administrator before
+the workshop.
+
+</Callout>
+
+Microsoft maintains the current [WSL installation guide](https://learn.microsoft.com/windows/wsl/install).
+
+Open **PowerShell as Administrator** and run:
+
+```powershell
+wsl --install -d Ubuntu
+wsl --update
+wsl --status
+wsl --version
+wsl --list --verbose
+```
+
+Restart Windows if prompted, open **Ubuntu** from the Start menu, and finish its Linux
+username and password setup. These credentials are separate from the Windows login and
+are used by `sudo`. In the PowerShell output, Ubuntu must show `VERSION 2` and WSL must
+report a current version. If Ubuntu shows version 1, run `wsl --set-version Ubuntu 2` in
+Administrator PowerShell.
+
+Install [Docker Desktop for Windows](https://docs.docker.com/desktop/setup/install/windows-install/).
+In Docker Desktop, enable **Settings -> General -> Use the WSL 2 based engine**, then
+**Settings -> Resources -> WSL Integration -> Ubuntu**. Docker and WSL must expose at
+least 6 GB of memory; the verification below reports the exact value. Do not install a
+second Docker Engine with `apt` inside Ubuntu; the Docker Desktop integration supplies it.
+
+Now open the **Ubuntu** terminal and install the Linux prerequisites:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl git python3
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+sudo apt-get install -y nodejs
+git config --global core.autocrlf input
+```
+
+Still in Ubuntu, verify the toolchain and your working directory:
+
+```bash
+docker version
+docker compose version
+docker info --format 'Docker memory: {{.MemTotal}} bytes'
+git --version
+node --version
+python3 --version
+pwd
+```
+
+Continue only when every command succeeds, Docker shows Client and Server sections, and
+Docker reports at least `6442450944` bytes (6 GB), and `pwd` begins with `/home/`. If
+Docker reports less memory, apply the `.wslconfig` fix in
+[Troubleshooting](/docs/learner/troubleshooting#wsl-or-docker-has-less-than-6-gb-of-memory).
+Do not put the repository under `/mnt/c`; Linux files are faster and avoid permission and
+line-ending failures. Windows can still open the local app at
+[localhost:8080](http://localhost:8080) in its normal browser.
+
+</PlatformOnly>
 
 <Callout type="warn" title="Managed laptop?">
   Corporate policy can block MCP installation or browser OAuth. Use a personal machine or
@@ -33,6 +130,22 @@ python3 --version
 </Callout>
 
 ## Step 2 — Clone the repo and switch to the workshop branch
+
+<PlatformOnly platform="macos">
+
+Run this in macOS Terminal:
+
+</PlatformOnly>
+
+<PlatformOnly platform="windows">
+
+Run this in the Ubuntu terminal. Start in your Linux home directory, not `/mnt/c`:
+
+```bash
+cd ~
+```
+
+</PlatformOnly>
 
 ```bash
 git clone https://github.com/ClickHouse/ClickHouse_Demos.git
@@ -42,7 +155,8 @@ cd workshops/build_workshop/app
 cp .env.workshop.example .env.workshop
 ```
 
-Keep this terminal in `ClickHouse_Demos/workshops/build_workshop/app`. The preflight script
+Keep this terminal in `ClickHouse_Demos/workshops/build_workshop/app`. On Windows, this
+means the Ubuntu terminal. The preflight script
 is `./preflight.sh` **inside this directory**. Stay on `build-workshop-v1` except during
 Module 07 fault tests. Confirm the branch now:
 
@@ -51,6 +165,19 @@ git branch --show-current
 ```
 
 Expected: `build-workshop-v1`.
+
+<PlatformOnly platform="windows">
+
+Your coding agent must use this same WSL checkout:
+
+- Run CLI agents such as Claude Code or Codex from the Ubuntu terminal.
+- In a desktop agent such as Cursor or Windsurf, open the WSL folder through its WSL
+  integration. The integrated terminal must report Linux when you run `uname -s`.
+- Do not create or open a second copy under `C:\Users`. If a Windows folder picker is
+  required, the checkout is under
+  `\\wsl.localhost\Ubuntu\home\<your-linux-user>\ClickHouse_Demos`.
+
+</PlatformOnly>
 
 ## Step 3 — Create a ClickHouse Cloud account and API key
 
@@ -73,6 +200,8 @@ clickhouse client --version
 ```
 
 Add `~/.local/bin` to your shell profile if a new terminal cannot find either command.
+On Windows, both commands are installed inside Ubuntu; do not install or run their Windows
+executables in PowerShell.
 
 ## Step 5 — Authenticate `clickhousectl`
 

--- a/workshops/build_workshop/playbook/content/docs/learner/index.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/index.mdx
@@ -8,6 +8,10 @@ on ClickHouse Cloud: real historical analytics, a live change-data-capture strea
 conversational BI, an AI-built SRE dashboard, and an in-app AI chat traced end to end.
 Work the modules in order - the numbered list below doubles as your progress tracker.
 
+The workshop supports **macOS** and **Windows**. Choose your computer in the page header;
+the choice persists across every learner and instructor page. Windows learners use Ubuntu
+on WSL 2, so all shared command blocks are identical after setup.
+
 ## Your progress
 
 0. [Setup](/docs/learner/00-setup) - accounts, keys, tools, agent skills, and the app running locally.

--- a/workshops/build_workshop/playbook/content/docs/learner/self-paced.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/self-paced.mdx
@@ -7,6 +7,10 @@ This workshop is designed to run in a room with an instructor, but everything yo
 finish it alone is already in this playbook. If you are working through the repository on
 your own - or someone shared it with you after the event - this page is your map.
 
+Choose **macOS** or **Windows** in the page header before setup. Windows learners run all
+workshop commands in Ubuntu on WSL 2; PowerShell appears only in explicitly labelled
+Windows bootstrap and recovery blocks.
+
 ## What changes without an instructor
 
 Short answer: nothing in modules 00 through 07. The primary path is fully self-serve. You

--- a/workshops/build_workshop/playbook/content/docs/learner/troubleshooting.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/troubleshooting.mdx
@@ -8,6 +8,114 @@ workshop. Find your symptom, read the why, apply the fix. If nothing here matche
 the problem to your coding agent - the [self-paced guide](/docs/learner/self-paced#your-coding-agent-is-your-instructor)
 has a ready-to-paste prompt that turns it into your instructor.
 
+## Windows and WSL 2
+
+### `wsl --install` is unavailable or only prints help
+
+- **Symptom** - Administrator PowerShell does not recognize `wsl --install`, or it prints
+  help instead of installing Ubuntu.
+- **Why** - Windows is below the workshop minimum, pending updates have not been applied,
+  or corporate policy disables WSL.
+- **Fix** - run Windows Update and confirm Windows 11 or Windows 10 version 2004 (build
+  19041) or later. Restart, then follow
+  [Microsoft's manual WSL installation steps](https://learn.microsoft.com/windows/wsl/install-manual).
+  On a managed machine, an administrator must permit the required Windows features.
+
+### A command is "not recognized" in PowerShell
+
+- **Symptom** - PowerShell rejects `./preflight.sh`, `export`, `source`, or another Bash
+  command from the workshop.
+- **Why** - Windows setup uses PowerShell only for the explicitly labelled WSL bootstrap.
+  Workshop commands run inside Ubuntu on WSL 2.
+- **Fix** - open **Ubuntu** from the Start menu, then return to the app directory and run
+  preflight there:
+
+  ```bash
+  cd ~/ClickHouse_Demos/workshops/build_workshop/app
+  ./preflight.sh
+  ```
+
+### The repository is under `/mnt/c`
+
+- **Symptom** - Docker bind mounts are slow, scripts have permission or line-ending
+  failures, or the repository path begins `/mnt/c/Users/...`.
+- **Why** - the repository was cloned onto the Windows filesystem instead of WSL's Linux
+  filesystem.
+- **Fix** - keep the old copy only if you need uncommitted work. Otherwise, open Ubuntu
+  and clone a clean copy in your Linux home directory:
+
+  ```bash
+  cd ~
+  git config --global core.autocrlf input
+  git clone https://github.com/ClickHouse/ClickHouse_Demos.git
+  cd ClickHouse_Demos
+  git switch build-workshop-v1
+  cd workshops/build_workshop/app
+  cp .env.workshop.example .env.workshop
+  ```
+
+### Ubuntu is running as WSL 1
+
+- **Symptom** - `wsl --list --verbose` shows Ubuntu with `VERSION 1`, or Docker Desktop
+  cannot integrate with the distro.
+- **Why** - the distro predates WSL 2 or was installed with WSL 1 as its default.
+- **Fix** - open **PowerShell as Administrator**, convert it, then reopen Ubuntu:
+
+  ```powershell
+  wsl --set-version Ubuntu 2
+  wsl --set-default-version 2
+  wsl --list --verbose
+  ```
+
+### `docker` is unavailable inside Ubuntu
+
+- **Symptom** - Docker Desktop is running, but Ubuntu says `docker: command not found` or
+  cannot reach the daemon.
+- **Why** - Docker Desktop's WSL engine or Ubuntu integration is disabled.
+- **Fix** - enable **Docker Desktop -> Settings -> General -> Use the WSL 2 based engine**
+  and **Resources -> WSL Integration -> Ubuntu**, apply the change, then run
+  `wsl --shutdown` in PowerShell and reopen Ubuntu. `docker version` must then show both
+  Client and Server sections.
+
+### WSL or Docker has less than 6 GB of memory
+
+- **Symptom** - preflight reports insufficient memory, or
+  `docker info --format 'Docker memory: {{.MemTotal}} bytes'` prints less than
+  `6442450944` bytes.
+- **Why** - Docker Desktop's WSL 2 backend uses the WSL virtual machine's memory limit.
+- **Fix** - close Docker Desktop, open PowerShell, and create an 8 GB WSL limit:
+
+  ```powershell
+  @('[wsl2]', 'memory=8GB', 'processors=4') |
+    Set-Content -Encoding ascii "$env:USERPROFILE\.wslconfig"
+  wsl --shutdown
+  ```
+
+  Start Docker Desktop and reopen Ubuntu. Re-run the `docker info` command and preflight.
+
+### A script reports `/usr/bin/env: 'bash\r': No such file or directory`
+
+- **Symptom** - a `.sh` file fails immediately and the error includes `bash\r` or `^M`.
+- **Why** - Windows CRLF line endings replaced the repository's required LF endings.
+- **Fix** - in Ubuntu, set Git's WSL policy and restore a clean checkout:
+
+  ```bash
+  git config --global core.autocrlf input
+  git status --short
+  git add --renormalize .
+  ```
+
+  Review `git status` before discarding or committing anything. If the checkout has no
+  work you need, a clean clone under `~/ClickHouse_Demos` is the safest recovery.
+
+### OAuth does not open the Windows browser
+
+- **Symptom** - an MCP login prints a URL but no browser window opens.
+- **Why** - the coding agent is running inside WSL and browser forwarding is unavailable
+  or blocked by corporate policy.
+- **Fix** - copy the complete login URL from Ubuntu and paste it into the normal Windows
+  browser. Complete authorization there, then return to the Ubuntu terminal.
+
 ## Docker
 
 ### Containers stick in "Created" and never start

--- a/workshops/build_workshop/playbook/src/app/docs/[[...slug]]/page.tsx
+++ b/workshops/build_workshop/playbook/src/app/docs/[[...slug]]/page.tsx
@@ -12,6 +12,7 @@ import { getMDXComponents } from '@/components/mdx';
 import type { Metadata } from 'next';
 import { createRelativeLink } from 'fumadocs-ui/mdx';
 import { gitConfig } from '@/lib/shared';
+import { PlatformSelector, PlatformShellNote } from '@/components/platform';
 
 export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
   const params = await props.params;
@@ -25,13 +26,17 @@ export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
     <DocsPage toc={page.data.toc} full={page.data.full}>
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription className="mb-0">{page.data.description}</DocsDescription>
-      <div className="flex flex-row gap-2 items-center border-b pb-6">
-        <MarkdownCopyButton markdownUrl={markdownUrl} />
-        <ViewOptionsPopover
-          markdownUrl={markdownUrl}
-          githubUrl={`https://github.com/${gitConfig.user}/${gitConfig.repo}/blob/${gitConfig.branch}/content/docs/${page.path}`}
-        />
+      <div className="workshop-doc-toolbar border-b pb-6">
+        <div className="flex flex-row gap-2 items-center">
+          <MarkdownCopyButton markdownUrl={markdownUrl} />
+          <ViewOptionsPopover
+            markdownUrl={markdownUrl}
+            githubUrl={`https://github.com/${gitConfig.user}/${gitConfig.repo}/blob/${gitConfig.branch}/content/docs/${page.path}`}
+          />
+        </div>
+        <PlatformSelector compact />
       </div>
+      <PlatformShellNote />
       <DocsBody>
         <MDX
           components={getMDXComponents({

--- a/workshops/build_workshop/playbook/src/app/global.css
+++ b/workshops/build_workshop/playbook/src/app/global.css
@@ -63,3 +63,126 @@ html > body[data-scroll-locked] {
   margin-right: 0px !important;
   --removed-body-scroll-bar-size: 0px !important;
 }
+
+/* Persistent workshop platform choice. Learners choose once; every docs page then
+ * reinforces the shell contract before showing any commands. */
+.workshop-platform-selector {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: var(--color-fd-foreground);
+}
+
+.workshop-platform-label {
+  font-size: 0.8125rem;
+  font-weight: 650;
+  white-space: nowrap;
+}
+
+.workshop-platform-options {
+  display: inline-flex;
+  gap: 0.2rem;
+  padding: 0.2rem;
+  border: 1px solid var(--color-fd-border);
+  border-radius: 0.65rem;
+  background: var(--color-fd-muted);
+}
+
+.workshop-platform-option {
+  min-height: 2.5rem;
+  padding: 0.35rem 0.75rem;
+  border: 0;
+  border-radius: 0.45rem;
+  background: transparent;
+  color: var(--color-fd-muted-foreground);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  font-weight: 650;
+}
+
+.workshop-platform-option[aria-checked='true'] {
+  background: var(--color-fd-primary);
+  color: var(--color-fd-primary-foreground);
+}
+
+.workshop-platform-option:focus-visible {
+  outline: 3px solid var(--color-fd-ring);
+  outline-offset: 2px;
+}
+
+.workshop-doc-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.workshop-shell-note {
+  margin-top: 1rem;
+  padding: 0.75rem 0.9rem;
+  border-left: 3px solid var(--color-fd-primary);
+  border-radius: 0.35rem;
+  background: var(--color-fd-muted);
+  color: var(--color-fd-muted-foreground);
+  font-size: 0.875rem;
+  line-height: 1.45;
+}
+
+.workshop-shell-note strong {
+  color: var(--color-fd-foreground);
+}
+
+.landing-platform-choice {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.65rem 1rem;
+  margin: 1.25rem 0 1.5rem;
+}
+
+.landing-platform-choice .workshop-platform-selector {
+  color: #fff;
+}
+
+.landing-platform-choice .workshop-platform-options {
+  border-color: rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.landing-platform-choice .workshop-platform-option {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.landing-platform-choice .workshop-platform-option[aria-checked='true'] {
+  background: #faff69;
+  color: #151515;
+}
+
+.landing-platform-choice > p {
+  max-width: 29rem;
+  margin: 0;
+  color: rgba(255, 255, 255, 0.67);
+  font-size: 1rem;
+  line-height: 1.4;
+}
+
+@media (max-width: 640px) {
+  .workshop-doc-toolbar {
+    align-items: flex-start;
+    flex-direction: column-reverse;
+  }
+
+  .workshop-platform-selector:not(.is-compact) {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .workshop-platform-options {
+    width: 100%;
+  }
+
+  .workshop-platform-option {
+    flex: 1;
+  }
+}

--- a/workshops/build_workshop/playbook/src/app/layout.tsx
+++ b/workshops/build_workshop/playbook/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { RootProvider } from 'fumadocs-ui/provider/next';
 import './global.css';
 import { Inter, Inconsolata } from 'next/font/google';
 import type { Metadata } from 'next';
+import { PlatformProvider } from '@/components/platform';
 
 const inter = Inter({
   subsets: ['latin'],
@@ -29,7 +30,7 @@ export default function Layout({ children }: LayoutProps<'/'>) {
     >
       <body className="flex flex-col min-h-screen">
         <RootProvider theme={{ defaultTheme: 'dark', enableSystem: false }}>
-          {children}
+          <PlatformProvider>{children}</PlatformProvider>
         </RootProvider>
       </body>
     </html>

--- a/workshops/build_workshop/playbook/src/app/page.tsx
+++ b/workshops/build_workshop/playbook/src/app/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import './landing.css';
+import { PlatformSelector } from '@/components/platform';
 
 // Workshop landing page (the site root, /). Ported from the standalone one-pager;
 // styles live in landing.css, scoped under `.op`. CTAs use next/link so they are
@@ -31,6 +32,10 @@ export default function LandingPage() {
                 <span className="chip"><b>100%</b> hands-on</span>
                 <span className="chip"><b>$0</b> on trial credits</span>
                 <span className="chip">bring your <b>own agent</b></span>
+              </div>
+              <div className="landing-platform-choice">
+                <PlatformSelector />
+                <p>Choose once. The workshop keeps the right setup visible on every page.</p>
               </div>
               <div className="cta">
                 <div className="cta-row">

--- a/workshops/build_workshop/playbook/src/components/mdx.tsx
+++ b/workshops/build_workshop/playbook/src/components/mdx.tsx
@@ -1,12 +1,14 @@
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 import type { MDXComponents } from 'mdx/types';
+import { PlatformOnly } from '@/components/platform';
 
 export function getMDXComponents(components?: MDXComponents) {
   return {
     ...defaultMdxComponents,
     Tab,
     Tabs,
+    PlatformOnly,
     ...components,
   } satisfies MDXComponents;
 }

--- a/workshops/build_workshop/playbook/src/components/platform.tsx
+++ b/workshops/build_workshop/playbook/src/components/platform.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from 'react';
+
+export type WorkshopPlatform = 'macos' | 'windows';
+
+const STORAGE_KEY = 'clickhouse-workshop-platform';
+
+type PlatformContextValue = {
+  platform: WorkshopPlatform;
+  setPlatform: (platform: WorkshopPlatform) => void;
+};
+
+const PlatformContext = createContext<PlatformContextValue | null>(null);
+
+function detectPlatform(): WorkshopPlatform {
+  const userAgent = navigator.userAgent.toLowerCase();
+  const navigatorPlatform = navigator.platform?.toLowerCase() ?? '';
+  return userAgent.includes('windows') || navigatorPlatform.startsWith('win')
+    ? 'windows'
+    : 'macos';
+}
+
+export function PlatformProvider({ children }: { children: ReactNode }) {
+  const [platform, setPlatformState] = useState<WorkshopPlatform>('macos');
+
+  useEffect(() => {
+    const saved = window.localStorage.getItem(STORAGE_KEY);
+    const initial = saved === 'macos' || saved === 'windows' ? saved : detectPlatform();
+    setPlatformState(initial);
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.dataset.workshopPlatform = platform;
+  }, [platform]);
+
+  const value = useMemo<PlatformContextValue>(
+    () => ({
+      platform,
+      setPlatform(nextPlatform) {
+        window.localStorage.setItem(STORAGE_KEY, nextPlatform);
+        setPlatformState(nextPlatform);
+      },
+    }),
+    [platform],
+  );
+
+  return <PlatformContext.Provider value={value}>{children}</PlatformContext.Provider>;
+}
+
+function usePlatform() {
+  const context = useContext(PlatformContext);
+  if (!context) throw new Error('Platform components require PlatformProvider');
+  return context;
+}
+
+export function PlatformSelector({ compact = false }: { compact?: boolean }) {
+  const { platform, setPlatform } = usePlatform();
+  const labelId = useId();
+
+  function moveWithKeyboard(event: KeyboardEvent<HTMLButtonElement>) {
+    let next: WorkshopPlatform | null = null;
+    if (['ArrowLeft', 'ArrowUp', 'Home'].includes(event.key)) next = 'macos';
+    if (['ArrowRight', 'ArrowDown', 'End'].includes(event.key)) next = 'windows';
+    if (!next) return;
+
+    event.preventDefault();
+    setPlatform(next);
+    const option = event.currentTarget.parentElement?.querySelector<HTMLButtonElement>(
+      `[data-platform="${next}"]`,
+    );
+    option?.focus();
+  }
+
+  return (
+    <div className={`workshop-platform-selector${compact ? ' is-compact' : ''}`}>
+      <span className="workshop-platform-label" id={labelId}>
+        Your computer
+      </span>
+      <div
+        aria-labelledby={labelId}
+        className="workshop-platform-options"
+        role="radiogroup"
+      >
+        <button
+          aria-checked={platform === 'macos'}
+          className="workshop-platform-option"
+          data-platform="macos"
+          onClick={() => setPlatform('macos')}
+          onKeyDown={moveWithKeyboard}
+          role="radio"
+          tabIndex={platform === 'macos' ? 0 : -1}
+          type="button"
+        >
+          macOS
+        </button>
+        <button
+          aria-checked={platform === 'windows'}
+          className="workshop-platform-option"
+          data-platform="windows"
+          onClick={() => setPlatform('windows')}
+          onKeyDown={moveWithKeyboard}
+          role="radio"
+          tabIndex={platform === 'windows' ? 0 : -1}
+          type="button"
+        >
+          Windows
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function PlatformShellNote() {
+  const { platform } = usePlatform();
+
+  return (
+    <div className="workshop-shell-note" role="status">
+      <strong>{platform === 'windows' ? 'Windows terminal:' : 'macOS terminal:'}</strong>{' '}
+      {platform === 'windows'
+        ? 'Run workshop commands in Ubuntu (WSL 2), not PowerShell. Use PowerShell only when a block explicitly says so.'
+        : 'Run workshop commands in Terminal using zsh or bash.'}
+    </div>
+  );
+}
+
+export function PlatformOnly({
+  platform,
+  children,
+}: {
+  platform: WorkshopPlatform;
+  children: ReactNode;
+}) {
+  const selected = usePlatform().platform;
+  if (selected !== platform) return null;
+  return <>{children}</>;
+}

--- a/workshops/build_workshop/scripts/check-windows.ps1
+++ b/workshops/build_workshop/scripts/check-windows.ps1
@@ -1,0 +1,101 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$WorkshopRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$ContentRoot = Join-Path $WorkshopRoot 'playbook/content/docs'
+$Setup = Join-Path $ContentRoot 'learner/00-setup.mdx'
+$Troubleshooting = Join-Path $ContentRoot 'learner/troubleshooting.mdx'
+$PlatformComponent = Join-Path $WorkshopRoot 'playbook/src/components/platform.tsx'
+$DocsPage = Join-Path $WorkshopRoot 'playbook/src/app/docs/[[...slug]]/page.tsx'
+
+function Assert-Literal {
+    param(
+        [Parameter(Mandatory = $true)][string]$Description,
+        [Parameter(Mandatory = $true)][string]$Literal,
+        [Parameter(Mandatory = $true)][string]$Path
+    )
+
+    $content = Get-Content -LiteralPath $Path -Raw
+    if (-not $content.Contains($Literal)) {
+        throw "Missing Windows workshop contract: $Description ($Literal in $Path)"
+    }
+}
+
+Assert-Literal 'persistent platform storage key' 'clickhouse-workshop-platform' $PlatformComponent
+Assert-Literal 'accessible platform selector' 'role="radiogroup"' $PlatformComponent
+Assert-Literal 'shell reminder on every docs page' '<PlatformShellNote />' $DocsPage
+Assert-Literal 'Ubuntu WSL 2 installation' 'wsl --install -d Ubuntu' $Setup
+Assert-Literal 'supported Windows prerequisite' 'Windows 10 version 2004 (build 19041)' $Setup
+Assert-Literal 'WSL status verification' 'wsl --status' $Setup
+Assert-Literal 'WSL version verification' 'wsl --version' $Setup
+Assert-Literal 'WSL is mandatory' 'WSL 1 are not supported workshop shells' $Setup
+Assert-Literal 'WSL 2 Docker engine guidance' 'Use the WSL 2 based engine' $Setup
+Assert-Literal 'Ubuntu Docker integration guidance' 'WSL Integration -> Ubuntu' $Setup
+Assert-Literal 'Linux-home checkout requirement' '`pwd` begins with `/home/`' $Setup
+Assert-Literal 'coding agent uses WSL checkout' 'Your coding agent must use this same WSL checkout' $Setup
+Assert-Literal 'desktop agent WSL terminal check' 'uname -s' $Setup
+Assert-Literal 'Git LF checkout policy' 'git config --global core.autocrlf input' $Setup
+Assert-Literal 'WSL memory recovery' '.wslconfig' $Troubleshooting
+Assert-Literal 'ClickHouse client verification' 'clickhouse client --version' $Setup
+Assert-Literal 'preflight path from repository root' 'workshops/build_workshop/app' $Setup
+Assert-Literal 'wrong-shell recovery' 'not recognized" in PowerShell' $Troubleshooting
+Assert-Literal 'CRLF recovery' "bash\r" $Troubleshooting
+Assert-Literal 'OAuth browser recovery' 'paste it into the normal Windows' $Troubleshooting
+
+$shellScripts = Get-ChildItem -Path $WorkshopRoot -Recurse -File -Include '*.sh', '*.bash'
+foreach ($script in $shellScripts) {
+    $bytes = [System.IO.File]::ReadAllBytes($script.FullName)
+    for ($index = 0; $index -lt ($bytes.Length - 1); $index++) {
+        if ($bytes[$index] -eq 13 -and $bytes[$index + 1] -eq 10) {
+            throw "Shell script must use LF line endings: $($script.FullName)"
+        }
+    }
+}
+
+$powershellScripts = Get-ChildItem -Path $WorkshopRoot -Recurse -File -Filter '*.ps1'
+foreach ($script in $powershellScripts) {
+    $tokens = $null
+    $errors = $null
+    [void][System.Management.Automation.Language.Parser]::ParseFile(
+        $script.FullName,
+        [ref]$tokens,
+        [ref]$errors
+    )
+    if ($errors.Count -gt 0) {
+        $messages = ($errors | ForEach-Object Message) -join '; '
+        throw "PowerShell parse failure in $($script.FullName): $messages"
+    }
+}
+
+$mdxFiles = Get-ChildItem -Path $ContentRoot -Recurse -File -Filter '*.mdx'
+$powershellBlockCount = 0
+foreach ($file in $mdxFiles) {
+    $content = Get-Content -LiteralPath $file.FullName -Raw
+    $fences = @(Select-String -LiteralPath $file.FullName -Pattern '^```').Count
+    if (($fences % 2) -ne 0) {
+        throw "Unbalanced code fences in $($file.FullName)"
+    }
+
+    $blocks = [regex]::Matches($content, '(?ms)^[ \t]*```powershell[ \t]*\r?\n(.*?)^[ \t]*```')
+    foreach ($block in $blocks) {
+        $powershellBlockCount++
+        $tokens = $null
+        $errors = $null
+        [void][System.Management.Automation.Language.Parser]::ParseInput(
+            $block.Groups[1].Value,
+            [ref]$tokens,
+            [ref]$errors
+        )
+        if ($errors.Count -gt 0) {
+            $messages = ($errors | ForEach-Object Message) -join '; '
+            throw "PowerShell fence parse failure in $($file.FullName): $messages"
+        }
+    }
+}
+
+if ($powershellBlockCount -lt 3) {
+    throw "Expected at least three tested PowerShell instruction blocks, found $powershellBlockCount"
+}
+
+Write-Host 'Windows workshop contract checks passed.'
+Write-Host "Validated $($shellScripts.Count) Bash scripts, $($powershellScripts.Count) PowerShell scripts, $powershellBlockCount PowerShell instruction blocks, and $($mdxFiles.Count) MDX files."

--- a/workshops/build_workshop/scripts/check-windows.ps1
+++ b/workshops/build_workshop/scripts/check-windows.ps1
@@ -42,7 +42,7 @@ Assert-Literal 'wrong-shell recovery' 'not recognized" in PowerShell' $Troublesh
 Assert-Literal 'CRLF recovery' "bash\r" $Troubleshooting
 Assert-Literal 'OAuth browser recovery' 'paste it into the normal Windows' $Troubleshooting
 
-$shellScripts = Get-ChildItem -Path $WorkshopRoot -Recurse -File -Include '*.sh', '*.bash'
+$shellScripts = @(Get-ChildItem -Path $WorkshopRoot -Recurse -File -Include '*.sh', '*.bash')
 foreach ($script in $shellScripts) {
     $bytes = [System.IO.File]::ReadAllBytes($script.FullName)
     for ($index = 0; $index -lt ($bytes.Length - 1); $index++) {
@@ -52,7 +52,7 @@ foreach ($script in $shellScripts) {
     }
 }
 
-$powershellScripts = Get-ChildItem -Path $WorkshopRoot -Recurse -File -Filter '*.ps1'
+$powershellScripts = @(Get-ChildItem -Path $WorkshopRoot -Recurse -File -Filter '*.ps1')
 foreach ($script in $powershellScripts) {
     $tokens = $null
     $errors = $null
@@ -67,7 +67,7 @@ foreach ($script in $powershellScripts) {
     }
 }
 
-$mdxFiles = Get-ChildItem -Path $ContentRoot -Recurse -File -Filter '*.mdx'
+$mdxFiles = @(Get-ChildItem -Path $ContentRoot -Recurse -File -Filter '*.mdx')
 $powershellBlockCount = 0
 foreach ($file in $mdxFiles) {
     $content = Get-Content -LiteralPath $file.FullName -Raw


### PR DESCRIPTION
Closes #63.

## Summary

- Adds a persistent, accessible macOS/Windows selector to the landing page and every documentation page.
- Defines Windows as Ubuntu on WSL 2 and makes the complete prerequisite, Docker Desktop, repository, coding-agent, ClickHouse CLI/client, and shell expectations explicit.
- Adds Windows/WSL recovery for unsupported Windows builds, WSL 1, missing Docker integration, low memory, `/mnt/c` checkouts, CRLF scripts, and browser OAuth.
- Adds mixed-platform instructor rehearsal guidance and a maintainer platform-authoring contract.
- Adds a required `windows-latest` CI job. It validates PowerShell scripts and documentation fences, LF Bash checkouts, backend tests, TypeScript, and the complete production build. Deployment now requires both Linux and Windows jobs.

## Test Coverage

The platform flow was exercised across these paths:

- macOS and Windows user-agent detection
- explicit platform selection and local-storage persistence
- route navigation and full reload persistence
- macOS/Windows conditional setup content
- Arrow, Home, and End keyboard navigation with radio state and focus
- learner Modules 00, 07, 08, troubleshooting, and instructor setup
- 375 px, 768 px, and 1280 px layouts with no horizontal overflow
- Windows prerequisite, WSL, Docker, memory, line-ending, agent-checkout, and OAuth contracts

## Pre-Landing Review

No critical or informational correctness findings. The selector has roving keyboard focus, unique accessible labels, 44 px+ touch targets, and visible focus treatment. The independent Codex CLI pass could not run because its configured API key was rejected; local review and CI gates remain complete.

## Design Review

Browser-verified at mobile, tablet, and desktop widths. No console errors or layout overflow. The Windows selection and shell reminder remain visible before the instructions.

## Scope Drift

Scope Check: CLEAN. All changes are limited to the macOS/Windows workshop experience and its CI enforcement.

## Plan Completion

All deliverables and test cases from #63 are addressed. The real Windows-hosted CI result is the final merge gate.

## Verification Results

- [x] Workshop documentation policy
- [x] Bash syntax and LF policy
- [x] TypeScript type-check
- [x] Production build: 99 static pages
- [x] Backend: 28 tests passed
- [x] Local route smoke: 31 documentation routes returned 200
- [x] Browser persistence, conditional content, keyboard behavior, responsive layout, and console checks
- [ ] GitHub `windows-latest` job, runs on this PR

## Test plan

- [ ] `Workshop CI` passes on Ubuntu
- [ ] `Windows compatibility` passes on `windows-latest`
- [ ] Merge deploys the exact revision to `dev-workshop.demohouse.cloud`
- [ ] Promotion merge deploys the same source to `workshop.demohouse.cloud`
