### PR TITLE
fix(rta-mini): load forex data from the neutral partner-workshop S3 bucket

### DIFF
--- a/workshops/RTA-mini-workshop/README.md
+++ b/workshops/RTA-mini-workshop/README.md
@@ -23,13 +23,14 @@ The guide loads a public forex Parquet dataset via a ClickPipe and via a one-sho
 `s3(...)` query:
 
 ```
-https://s3.housemate.click/fx/ticks.parquet
+https://partner-workshop.s3.ap-southeast-1.amazonaws.com/fx/ticks.parquet
 ```
 
-> **Note.** The dataset is served from a neutral custom domain
-> (`s3.housemate.click`), so the lab is fully partner-neutral. To host your own
-> copy, point a bucket at `fx/ticks.parquet` and update the two references in the
-> guide (`public/rta-mini/index.html`).
+> **Note.** The dataset lives in a neutral, public S3 bucket (`partner-workshop`
+> in `ap-southeast-1`), so the lab is fully partner-neutral and works with both
+> the ClickPipes S3 source and the `s3()` function (anonymous `GetObject` +
+> `ListBucket`). To host your own copy, upload `fx/ticks.parquet` to a public
+> bucket and update the two references in the guide (`public/rta-mini/index.html`).
 
 ## Prerequisites (participants)
 

--- a/workshops/build_workshop/playbook/public/rta-mini/index.html
+++ b/workshops/build_workshop/playbook/public/rta-mini/index.html
@@ -351,7 +351,7 @@ ORDER BY (base, quote, datetime);</code></pre>
       </ol>
       <div class="code">
         <div class="bar"><span class="lang">S3 file path</span><button class="copy-btn">Copy</button></div>
-        <pre><code>https://s3.housemate.click/fx/ticks.parquet</code></pre>
+        <pre><code>https://partner-workshop.s3.ap-southeast-1.amazonaws.com/fx/ticks.parquet</code></pre>
       </div>
       <p>Leave <em>Continuous ingestion</em> off (this is a one-time file), then click <strong>Incoming data →</strong>.</p>
       <figure class="shot">
@@ -410,7 +410,7 @@ TRUNCATE TABLE forex;
 
 -- load all ~26.5M ticks from the public S3 file in one line (server-side)
 INSERT INTO forex
-SELECT * FROM s3('https://s3.housemate.click/fx/ticks.parquet', NOSIGN, 'Parquet');
+SELECT * FROM s3('https://partner-workshop.s3.ap-southeast-1.amazonaws.com/fx/ticks.parquet', NOSIGN, 'Parquet');
 
 -- and check again (expect 26,488,218)
 SELECT count() AS ticks, uniqExact(concat(base,'/',quote)) AS pairs FROM forex;</code></pre>


### PR DESCRIPTION
Fixes the broken `s3()` step from #69. The `s3.housemate.click` custom domain works in a browser but not for ClickHouse's `s3()` or the ClickPipes S3 source (both parse an S3 bucket from the URL → `fx` read as a too-short bucket name).

Points both load methods (ClickPipes S3 path + the `s3()` one-liner) at the native URL of a new neutral public bucket:

`https://partner-workshop.s3.ap-southeast-1.amazonaws.com/fx/ticks.parquet`

The bucket has anonymous `s3:GetObject` + `s3:ListBucket` (verified: HTTP 200 GET, anonymous LIST returns the object), matching the old bucket's public access. Fully partner-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)