### PR TITLE
docs(workshop): clarify training keys and code readability

### DIFF
--- a/workshops/build_workshop/playbook/content/docs/instructor/00-setup.mdx
+++ b/workshops/build_workshop/playbook/content/docs/instructor/00-setup.mdx
@@ -16,6 +16,14 @@ For mixed rooms, budget another 10 minutes before the session for Windows learne
 have not yet installed WSL 2 and Docker Desktop. A restart can be required after
 `wsl --install`.
 
+For in-person sessions with trainer-provided credentials:
+
+- Issue separate temporary ClickHouse Cloud organization and OpenAI project API keys to
+  each learner. Never share one key across the room.
+- Deliver each key through an approved secret-sharing channel, not chat or slides.
+- Apply an OpenAI project budget and rate limits, then monitor usage during the session.
+- Revoke both keys after the workshop. Rotate either key immediately if it is exposed.
+
 ## Talk track
 
 - Frame the session: they will move an existing app onto ClickHouse Cloud, and the agent

--- a/workshops/build_workshop/playbook/content/docs/learner/00-setup.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/00-setup.mdx
@@ -185,6 +185,9 @@ Your coding agent must use this same WSL checkout:
 
 ## Step 3 — Create a ClickHouse Cloud account and API key
 
+**In-person training:** Use the ClickHouse Cloud organization API key provided by your
+trainer and skip this step.
+
 1. Sign in or start a trial at [console.clickhouse.cloud](https://console.clickhouse.cloud).
 2. Open **API Keys**, create an **Admin** organization key, and save its Key ID and secret.
 

--- a/workshops/build_workshop/playbook/content/docs/learner/00-setup.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/00-setup.mdx
@@ -185,8 +185,8 @@ Your coding agent must use this same WSL checkout:
 
 ## Step 3 — Create a ClickHouse Cloud account and API key
 
-**In-person training:** Use the ClickHouse Cloud organization API key provided by your
-trainer and skip this step.
+**In-person training:** Use the learner-specific ClickHouse Cloud organization API key
+provided securely by your trainer and skip this step.
 
 1. Sign in or start a trial at [console.clickhouse.cloud](https://console.clickhouse.cloud).
 2. Open **API Keys**, create an **Admin** organization key, and save its Key ID and secret.
@@ -363,6 +363,9 @@ setup later; Modules 06 and 07 use the `clickstack` connection configured here.
 ## Step 8 — Create Langfuse and OpenAI keys
 
 Langfuse records the AI chat traces used in Module 08.
+
+**In-person training:** Use the learner-specific OpenAI project API key provided securely
+by your trainer and skip item 3. You still need the Langfuse keys from items 1 and 2.
 
 1. Create a project at [US Langfuse Cloud](https://us.cloud.langfuse.com) or
    [EU Langfuse Cloud](https://cloud.langfuse.com).

--- a/workshops/build_workshop/playbook/content/docs/learner/06b-ai-sre-librechat.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/06b-ai-sre-librechat.mdx
@@ -90,7 +90,6 @@ The agent should connect the `nyc-taxi-frontend` error to
 ## Completion check
 
 - LibreChat is reached through an instructor-provided or self-paced **HTTPS cloud URL**.
-- No LibreChat, MongoDB, PostgreSQL, ClickHouse, or HyperDX server runs locally.
 - The agent has connected remote `clickstack` and `github` MCP tools.
 - Its diagnosis cites both telemetry and a source file on the selected fault branch.
 

--- a/workshops/build_workshop/playbook/src/app/global.css
+++ b/workshops/build_workshop/playbook/src/app/global.css
@@ -15,6 +15,11 @@
   --font-mono: var(--font-inconsolata), ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
+/* Fumadocs renders fenced code blocks at 0.8125rem. Increase them by exactly 2pt. */
+.shiki > div[role='region'] {
+  font-size: calc(0.8125rem + 2pt);
+}
+
 /* Light (toggle) */
 :root {
   --color-fd-background: #ffffff;


### PR DESCRIPTION
## Summary
- remove the redundant local-server completion bullet from learner Module 06b
- tell in-person learners to use trainer-provided, learner-specific ClickHouse Cloud and OpenAI project keys
- add instructor guidance for secure delivery, OpenAI budget/rate limits, monitoring, and post-workshop revocation
- increase every fenced workshop code block by exactly 2pt without changing inline code

## Safety
- avoids implying that one ClickHouse or OpenAI key should be shared across the room
- follows OpenAI key-safety guidance: https://help.openai.com/en/articles/5112595-best-practices-for-api-key-safety

## Verification
- workshop documentation policy checks passed
- playbook TypeScript/MDX checks passed
- production Next.js build passed
- browser QA found 20 fenced blocks at the increased computed size; inline code remains 13px
- both learner notes render in the built page
- independent adversarial review: CLEAN

## Test plan
- [x] Linux Workshop CI
- [x] Windows compatibility CI
- [x] Browser verification on learner setup
- [x] Verify Module 06b sentence is absent