### PR TITLE
chore(workshop): promote verified key guidance and code readability

### DIFF
--- a/workshops/build_workshop/playbook/content/docs/instructor/00-setup.mdx
+++ b/workshops/build_workshop/playbook/content/docs/instructor/00-setup.mdx
@@ -16,6 +16,14 @@ For mixed rooms, budget another 10 minutes before the session for Windows learne
 have not yet installed WSL 2 and Docker Desktop. A restart can be required after
 `wsl --install`.
 
+For in-person sessions with trainer-provided credentials:
+
+- Issue separate temporary ClickHouse Cloud organization and OpenAI project API keys to
+  each learner. Never share one key across the room.
+- Deliver each key through an approved secret-sharing channel, not chat or slides.
+- Apply an OpenAI project budget and rate limits, then monitor usage during the session.
+- Revoke both keys after the workshop. Rotate either key immediately if it is exposed.
+
 ## Talk track
 
 - Frame the session: they will move an existing app onto ClickHouse Cloud, and the agent

--- a/workshops/build_workshop/playbook/content/docs/learner/00-setup.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/00-setup.mdx
@@ -185,6 +185,9 @@ Your coding agent must use this same WSL checkout:
 
 ## Step 3 — Create a ClickHouse Cloud account and API key
 
+**In-person training:** Use the ClickHouse Cloud organization API key provided by your
+trainer and skip this step.
+
 1. Sign in or start a trial at [console.clickhouse.cloud](https://console.clickhouse.cloud).
 2. Open **API Keys**, create an **Admin** organization key, and save its Key ID and secret.
 

--- a/workshops/build_workshop/playbook/content/docs/learner/00-setup.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/00-setup.mdx
@@ -185,8 +185,8 @@ Your coding agent must use this same WSL checkout:
 
 ## Step 3 — Create a ClickHouse Cloud account and API key
 
-**In-person training:** Use the ClickHouse Cloud organization API key provided by your
-trainer and skip this step.
+**In-person training:** Use the learner-specific ClickHouse Cloud organization API key
+provided securely by your trainer and skip this step.
 
 1. Sign in or start a trial at [console.clickhouse.cloud](https://console.clickhouse.cloud).
 2. Open **API Keys**, create an **Admin** organization key, and save its Key ID and secret.
@@ -363,6 +363,9 @@ setup later; Modules 06 and 07 use the `clickstack` connection configured here.
 ## Step 8 — Create Langfuse and OpenAI keys
 
 Langfuse records the AI chat traces used in Module 08.
+
+**In-person training:** Use the learner-specific OpenAI project API key provided securely
+by your trainer and skip item 3. You still need the Langfuse keys from items 1 and 2.
 
 1. Create a project at [US Langfuse Cloud](https://us.cloud.langfuse.com) or
    [EU Langfuse Cloud](https://cloud.langfuse.com).

--- a/workshops/build_workshop/playbook/content/docs/learner/06b-ai-sre-librechat.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/06b-ai-sre-librechat.mdx
@@ -90,7 +90,6 @@ The agent should connect the `nyc-taxi-frontend` error to
 ## Completion check
 
 - LibreChat is reached through an instructor-provided or self-paced **HTTPS cloud URL**.
-- No LibreChat, MongoDB, PostgreSQL, ClickHouse, or HyperDX server runs locally.
 - The agent has connected remote `clickstack` and `github` MCP tools.
 - Its diagnosis cites both telemetry and a source file on the selected fault branch.
 

--- a/workshops/build_workshop/playbook/src/app/global.css
+++ b/workshops/build_workshop/playbook/src/app/global.css
@@ -15,6 +15,11 @@
   --font-mono: var(--font-inconsolata), ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
+/* Fumadocs renders fenced code blocks at 0.8125rem. Increase them by exactly 2pt. */
+.shiki > div[role='region'] {
+  font-size: calc(0.8125rem + 2pt);
+}
+
 /* Light (toggle) */
 :root {
   --color-fd-background: #ffffff;


### PR DESCRIPTION
## Summary
Promote the dev-verified workshop updates to production:

- remove the redundant Module 06b local-server completion bullet
- add safe in-person ClickHouse Cloud and OpenAI key guidance for learners and instructors
- increase fenced code blocks by exactly 2pt while leaving inline code unchanged

## Dev verification
- deployment run: https://github.com/ClickHouse/ClickHouse_Demos/actions/runs/30329320392
- live learner setup returned HTTP 200 with no login redirect
- all 20 fenced blocks compute to 15.6667px; inline code remains 13px
- both learner credential notes render
- removed Module 06b sentence is absent; the remaining completion checks still render
- no critical console errors

## Test plan
- [x] Linux Workshop CI
- [x] Windows compatibility CI
- [x] Dev deployment health checks
- [x] Live browser verification on dev