### PR TITLE
promote workshop: archive Module 06b and simplify workshop flow

### DIFF
--- a/workshops/build_workshop/README.md
+++ b/workshops/build_workshop/README.md
@@ -15,8 +15,8 @@ feature branch, open a PR to protected `dev-build-workshop-v1`, verify
 ## Architecture
 
 The app edge runs on the participant's laptop. ClickHouse, Postgres, ClickPipes, and
-ClickStack/HyperDX live in ClickHouse Cloud; OpenAI, Langfuse, and optional LibreChat are
-separate hosted services. No database or product UI is deployed locally.
+ClickStack/HyperDX live in ClickHouse Cloud; OpenAI and Langfuse are separate hosted
+services. No database or product UI is deployed locally.
 
 ```mermaid
 flowchart LR
@@ -40,7 +40,6 @@ flowchart LR
   subgraph THIRD["Third-party"]
     OAI["OpenAI API<br/>chat completions"]
     LF["Langfuse Cloud<br/>chat traces"]
-    LC["Hosted LibreChat<br/>optional SRE chat"]
     TLC["NYC TLC public dataset<br/>download source only"]
   end
 
@@ -58,7 +57,6 @@ flowchart LR
   TLC -.->|url seed, module 01| CH
   HDX -->|reads otel db| CH
   AG -->|RBAC-governed SQL| CH
-  LC -.->|remote MCP| MCP
 ```
 
 The published diagrams (the ClickHouse Cloud platform stack, the workshop architecture, the

--- a/workshops/build_workshop/README.md
+++ b/workshops/build_workshop/README.md
@@ -98,7 +98,7 @@ sequenceDiagram
   G->>P: INSERT trips (throttled, TLS)
   Note over G,P: first run also creates the table<br/>and publication pub_taxi
   P->>CP: WAL changes via publication + slot
-  CP->>CH: rows land in realtime_trips (_peerdb_* cols), about 60s
+  CP->>CH: rows land in default.realtime_trips, about 60s
   CH->>CH: materialized view fans rows into nyc_tlc_data.taxi_trips
   UI->>CH: parameterized SQL / guarded NL-to-SQL / RBAC-governed BI
   CH-->>UI: live Ops dashboard + 3M-row Historical seed

--- a/workshops/build_workshop/app/OBSERVABILITY.md
+++ b/workshops/build_workshop/app/OBSERVABILITY.md
@@ -107,12 +107,12 @@ cp .env.workshop.example .env.workshop
 
 # 2) Bring up the stack with the overlay:
 docker compose --env-file .env.workshop \
-  -f docker-compose.workshop.yml -f docker-compose.otel.yml up -d
+  -f docker-compose.workshop.yml -f docker-compose.otel.yml up -d --build
 
 # Optional: also scrape raw container stdout (see VERIFY-LIVE):
 docker compose --env-file .env.workshop \
   -f docker-compose.workshop.yml -f docker-compose.otel.yml \
-  --profile container-logs up -d
+  --profile container-logs up -d --build
 ```
 
 ## Environment variables

--- a/workshops/build_workshop/app/README.md
+++ b/workshops/build_workshop/app/README.md
@@ -48,7 +48,7 @@ docker compose --env-file .env.workshop -f docker-compose.workshop.yml up -d
 
 # with the ClickStack observability overlay (module 05 onward):
 docker compose --env-file .env.workshop \
-  -f docker-compose.workshop.yml -f docker-compose.otel.yml up -d
+  -f docker-compose.workshop.yml -f docker-compose.otel.yml up -d --build
 ```
 
 Frontend: http://localhost:8080 - Backend API docs (FastAPI Swagger):

--- a/workshops/build_workshop/app/WORKSHOP_CHANGES.md
+++ b/workshops/build_workshop/app/WORKSHOP_CHANGES.md
@@ -19,10 +19,9 @@ The workshop intentionally separates application code from managed services.
 - remote ClickHouse and ClickStack MCP endpoints
 - ClickHouse Agents
 - Langfuse Cloud and OpenAI
-- the optional instructor-provided HTTPS LibreChat instance
 
-No PostgreSQL, ClickHouse, MongoDB, LibreChat, HyperDX, Langfuse, or MCP server is
-started on a learner machine.
+No PostgreSQL, ClickHouse, MongoDB, HyperDX, Langfuse, or MCP server is started on a
+learner machine.
 
 ## Runtime sequence
 
@@ -30,8 +29,8 @@ started on a learner machine.
 2. Module 01 creates and seeds the Cloud schema.
 3. Module 03 creates managed Postgres, validates it with
    `./preflight.sh --require-postgres`, then explicitly enables the `cdc` trip writer.
-4. Module 05 enables Managed ClickStack and starts the stateless collector overlay.
-5. Module 06b uses hosted LibreChat; Module 08 sends chat traces to Langfuse Cloud.
+4. Module 05 starts the stateless collector overlay, then enables Managed ClickStack.
+5. Module 08 sends chat traces to Langfuse Cloud.
 
 `.env.workshop.example` leaves managed Postgres credentials blank until Module 03 and
 requires TLS. `preflight.sh` rejects loopback/local database hosts. CI policy checks in

--- a/workshops/build_workshop/app/docker-compose.otel.yml
+++ b/workshops/build_workshop/app/docker-compose.otel.yml
@@ -14,7 +14,7 @@
 # "ClickStack observability" section of .env.workshop.example):
 #
 #   docker compose --env-file .env.workshop \
-#     -f docker-compose.workshop.yml -f docker-compose.otel.yml up -d
+#     -f docker-compose.workshop.yml -f docker-compose.otel.yml up -d --build
 #
 # Add raw container-log scraping (optional, see VERIFY-LIVE notes in OBSERVABILITY.md):
 #   ... -f docker-compose.otel.yml --profile container-logs up -d

--- a/workshops/build_workshop/docs/diagrams/gen_diagrams.py
+++ b/workshops/build_workshop/docs/diagrams/gen_diagrams.py
@@ -46,11 +46,11 @@ def box(x, y, w, h, title, lines=None, accent=False, rounded=12, fill=BOX_FILL, 
     cx = x + w / 2
     # title
     ty = y + (22 if lines else h/2 + 5)
-    s += (f'<text x="{cx}" y="{ty}" fill="{INK}" font-size="15" font-weight="600" '
+    s += (f'<text x="{cx}" y="{ty}" fill="{INK}" font-size="17" font-weight="600" '
           f'text-anchor="middle">{escape(title)}</text>\n')
     if lines:
         for i, ln in enumerate(lines):
-            s += (f'<text x="{cx}" y="{y+44+i*18}" fill="{SUBINK}" font-size="12.5" '
+            s += (f'<text x="{cx}" y="{y+44+i*18}" fill="{SUBINK}" font-size="14" '
                   f'text-anchor="middle">{escape(ln)}</text>\n')
     return s
 
@@ -60,7 +60,7 @@ def zone(x, y, w, h, key):
     s = (f'<rect x="{x}" y="{y}" width="{w}" height="{h}" rx="16" fill="{z["fill"]}" '
          f'stroke="{z["stroke"]}" stroke-width="1.6" opacity="0.96"/>\n')
     s += (f'<text x="{x+18}" y="{y+26}" fill="{z["stroke"] if key!="cloud" else YELLOW}" '
-          f'font-size="13" font-weight="700" letter-spacing="0.5">{escape(z["label"])}</text>\n')
+          f'font-size="15" font-weight="700" letter-spacing="0.5">{escape(z["label"])}</text>\n')
     return s
 
 
@@ -72,9 +72,9 @@ def edge(x1, y1, x2, y2, label=None, mid=None, dashed=False, label_dx=0, label_d
         lx = (x1 + x2) / 2 + label_dx if mid is None else mid[0]
         ly = (y1 + y2) / 2 + label_dy if mid is None else mid[1]
         w = 7.2 * len(label) + 10
-        s += (f'<rect x="{lx-w/2}" y="{ly-13}" width="{w}" height="18" rx="4" '
-              f'fill="{BG}" opacity="0.92"/>\n')
-        s += (f'<text x="{lx}" y="{ly}" fill="{SUBINK}" font-size="11.5" '
+        s += (f'<rect x="{lx-w/2}" y="{ly-14}" width="{w}" height="20" rx="4" '
+              f'fill="{BG}"/>\n')
+        s += (f'<text x="{lx}" y="{ly}" fill="{SUBINK}" font-size="12.5" '
               f'text-anchor="middle">{escape(label)}</text>\n')
     return s
 
@@ -87,9 +87,9 @@ def elbow(pts, label=None, mid=None, dashed=False):
          f'marker-end="url(#arrow)"/>\n')
     if label and mid:
         w = 7.2 * len(label) + 10
-        s += (f'<rect x="{mid[0]-w/2}" y="{mid[1]-13}" width="{w}" height="18" rx="4" '
-              f'fill="{BG}" opacity="0.92"/>\n')
-        s += (f'<text x="{mid[0]}" y="{mid[1]}" fill="{SUBINK}" font-size="11.5" '
+        s += (f'<rect x="{mid[0]-w/2}" y="{mid[1]-14}" width="{w}" height="20" rx="4" '
+              f'fill="{BG}"/>\n')
+        s += (f'<text x="{mid[0]}" y="{mid[1]}" fill="{SUBINK}" font-size="12.5" '
               f'text-anchor="middle">{escape(label)}</text>\n')
     return s
 
@@ -166,65 +166,42 @@ def module_flow():
 
 
 # ===========================================================================
-# ARCHITECTURE  (3 zones, aligned rows, top bus for third-party API calls)
+# ARCHITECTURE  (three simple groups; the data-flow diagram owns sequencing)
 # ===========================================================================
 def architecture():
-    W, H = 1700, 1000
+    W, H = 1500, 650
     s = _svg_header(W, H)
     s += (f'<text x="30" y="44" fill="{INK}" font-size="22" font-weight="700">'
-          f'ClickHouse BUILD Workshop · Architecture (target end state)</text>\n')
+          f'ClickHouse BUILD Workshop · Where each component runs</text>\n')
     s += (f'<text x="30" y="70" fill="{SUBINK}" font-size="13.5">'
-          f'App-side components run locally; stateful data services run in ClickHouse Cloud. '
-          f'Dashed lines are control/OAuth; solid lines are data.</text>\n')
+          f'Group components by location first. Follow the next diagram for the trip data path.</text>\n')
 
     # zones
-    s += zone(30, 135, 515, 700, "laptop")
-    s += zone(590, 135, 650, 760, "cloud")
-    s += zone(1290, 135, 380, 560, "third")
+    s += zone(30, 110, 430, 480, "laptop")
+    s += zone(510, 110, 620, 480, "cloud")
+    s += zone(1180, 110, 290, 480, "third")
 
-    # --- laptop boxes ---
-    s += box(60, 190, 455, 62, "frontend", ["React SPA · nginx :8080", "Ops + Historical dashboards, chat"])
-    s += box(60, 300, 455, 62, "backend", ["FastAPI :8000", "analytics API + /api/chat (NL-to-SQL)"])
-    s += box(60, 410, 455, 56, "otel-collector", ["ClickStack overlay (module 05)"])
-    s += box(60, 520, 455, 62, "pg-trip-writer", ["synthetic trips; creates the CDC", "table + publication on first run"])
-    s += box(60, 660, 455, 62, "coding agent + clickhousectl", ["Claude Code / Cursor / Codex", "+ ClickHouse skills + docs llms.txt"])
+    # Participant laptop: application edge and stateless tools only.
+    s += box(60, 165, 370, 78, "Frontend + FastAPI", ["dashboards, chat, and API", "runs with Docker Compose"])
+    s += box(60, 270, 370, 68, "Load generator", ["creates synthetic trip rows"])
+    s += box(60, 365, 370, 68, "OpenTelemetry forwarder", ["sends app telemetry to ClickStack"])
+    s += box(60, 460, 370, 78, "Coding agent + clickhousectl", ["workshop commands, MCP,", "and ClickHouse skills"])
 
-    # --- cloud boxes ---
-    s += box(620, 185, 590, 96, "ClickHouse service  :8443 TLS", ["nyc_tlc_data (taxi_trips, taxi_zones,", "views, CDC MV)   +   otel db (logs, traces)"], accent=True)
-    s += box(620, 330, 280, 88, "ClickPipes", ["Postgres CDC pipe", "snapshot + stream (~60s)"])
-    s += box(930, 330, 280, 88, "Managed ClickStack / HyperDX", ["traces + logs UI", "module 05"])
-    s += box(620, 500, 590, 82, "Postgres managed by ClickHouse  :5432 TLS", ["you create it with clickhousectl (module 03) · public.realtime_trips + pub_taxi"])
-    s += box(620, 628, 280, 74, "Remote MCP", ["/mcp + /clickstack (OAuth)"])
-    s += box(930, 628, 280, 74, "ClickHouse Agents", ["ai.clickhouse.cloud (module 04)"])
-    s += box(620, 748, 590, 60, "Instructor cloud fallback only", ["managed Postgres pool when a trial org cannot create one"], dashed=True, fill="#1C1B14")
+    # ClickHouse Cloud: state, ingestion, observability, and AI surfaces.
+    s += box(540, 165, 560, 88, "ClickHouse service", ["default.realtime_trips lands here", "nyc_tlc_data.taxi_trips powers the app"], accent=True)
+    s += box(540, 285, 265, 78, "Managed Postgres", ["public.realtime_trips"])
+    s += box(835, 285, 265, 78, "ClickPipes", ["streams Postgres changes"])
+    s += box(540, 395, 265, 88, "Managed ClickStack", ["HyperDX traces, logs,", "dashboards, and alerts"])
+    s += box(835, 395, 265, 88, "Agents + remote MCP", ["ask questions and let", "the coding agent use tools"])
 
-    # --- third-party boxes ---
-    s += box(1315, 195, 330, 74, "Langfuse Cloud", ["chat traces, sessions, cost"])
-    s += box(1315, 300, 330, 74, "OpenAI API", ["chat completions (gpt-5.4-mini)"])
-    s += box(1315, 410, 330, 88, "NYC TLC dataset", ["public parquet; read once by the", "module 01 seed. Data source only."])
+    # External services used by the app, kept separate from workshop data storage.
+    s += box(1210, 175, 230, 82, "OpenAI API", ["chat completions"])
+    s += box(1210, 290, 230, 82, "Langfuse Cloud", ["chat traces and cost"])
+    s += box(1210, 405, 230, 92, "NYC TLC dataset", ["one-time historical", "seed source"])
 
-    # --- edges (laptop internal) ---
-    s += edge(287, 252, 287, 300, "/api proxy", label_dx=42)
-    s += edge(180, 362, 180, 410, "OTLP", label_dx=-34)
-
-    # laptop -> cloud (near-horizontal, labels in the gap)
-    s += elbow([(515, 331), (560, 331), (560, 250), (620, 250)], "SQL · TLS :8443", mid=(567, 300))
-    s += elbow([(515, 438), (585, 438), (585, 262), (620, 262)], "traces → otel db", mid=(585, 400), dashed=False)
-    s += edge(515, 545, 620, 541, "INSERT trips · TLS", label_dy=-8)
-    s += edge(515, 690, 620, 665, "MCP · OAuth", label_dy=-8)
-
-    # cloud internal (CDC chain + reads)
-    s += edge(760, 500, 760, 418, "logical replication", label_dx=0, label_dy=-4)
-    s += edge(760, 330, 760, 281, "CDC rows ~60s", label_dy=-4)
-    s += edge(1070, 330, 1070, 281, "reads otel db", label_dy=-4)
-    # agents -> service (RBAC), up the cloud's right margin
-    s += elbow([(1070, 628), (1215, 628), (1215, 235), (1210, 235)], "RBAC SQL", mid=(1215, 470))
-
-    # third-party: backend -> OpenAI / Langfuse along the top bus (above zones)
-    s += elbow([(360, 300), (360, 118), (1480, 118), (1480, 300)], "chat completions", mid=(950, 112))
-    s += elbow([(330, 300), (330, 96), (1430, 96), (1430, 195)], "chat traces (Langfuse SDK)", mid=(760, 90))
-    # TLC seed -> service (in the cloud/third gap)
-    s += elbow([(1315, 452), (1262, 452), (1262, 215), (1210, 215)], "url() seed", mid=(1262, 305))
+    # Only zone-level relationships. Detailed sequencing belongs in data_flow().
+    s += edge(460, 565, 510, 565, "uses", mid=(485, 548))
+    s += edge(1130, 565, 1180, 565, "calls", mid=(1155, 548))
 
     s += "</svg>\n"
     return s
@@ -318,99 +295,56 @@ def platform_stack():
 
 
 # ===========================================================================
-# DATA FLOW  (four swimlanes: seed, live CDC, read, observe)
+# DATA FLOW  (one learner-facing left-to-right story)
 # ===========================================================================
 def data_flow():
-    W, H = 1560, 900
+    W, H = 1200, 620
     s = _svg_header(W, H)
     s += (f'<text x="30" y="44" fill="{INK}" font-size="22" font-weight="700">'
-          f'ClickHouse BUILD Workshop · Data flow</text>\n')
+          f'ClickHouse BUILD Workshop · A trip\'s path</text>\n')
     s += (f'<text x="30" y="70" fill="{SUBINK}" font-size="13.5">'
-          f'How a row moves: seeded once, streamed continuously, then read and observed — '
-          f'all through your ClickHouse service.</text>\n')
+          f'Read left to right: generate a trip, stream it into ClickHouse, then show it in the app.</text>\n')
 
-    LX, LW = 30, W - 60
-    TITLE_W = 176  # left title gutter per lane
+    xcols, yrows, bw, bh = [40, 450, 860], [135, 345], 300, 110
+    steps = [
+        ("Load generator", ["creates synthetic trips", "on your laptop"], False),
+        ("Managed Postgres", ["source table:", "public.realtime_trips"], False),
+        ("ClickPipes", ["streams each change", "with Postgres CDC"], False),
+        ("ClickHouse", ["first landing table:", "default.realtime_trips"], True),
+        ("Materialized view", ["moves new rows into", "nyc_tlc_data.taxi_trips"], False),
+        ("Frontend + FastAPI", ["reads taxi_trips for", "the live dashboards"], False),
+    ]
 
-    def lane(y, h, title, subtitle):
-        t = (f'<rect x="{LX}" y="{y}" width="{LW}" height="{h}" rx="14" fill="#1C1C22" '
-             f'stroke="#3A3A45" stroke-width="1.3"/>\n')
-        t += (f'<rect x="{LX}" y="{y}" width="6" height="{h}" rx="3" fill="{YELLOW}"/>\n')
-        t += (f'<text x="{LX+22}" y="{y+30}" fill="{INK}" font-size="14.5" '
-              f'font-weight="700">{escape(title)}</text>\n')
-        # wrap subtitle into the gutter
-        words, line, ln = subtitle.split(), "", 0
-        for wd in words:
-            if len(line) + len(wd) > 20:
-                t += (f'<text x="{LX+22}" y="{y+52+ln*16}" fill="{SUBINK}" '
-                      f'font-size="11">{escape(line)}</text>\n'); line = wd; ln += 1
-            else:
-                line = (line + " " + wd).strip()
-        if line:
-            t += (f'<text x="{LX+22}" y="{y+52+ln*16}" fill="{SUBINK}" font-size="11">{escape(line)}</text>\n')
-        return t
+    # Numbered snake: left-to-right on row one, then right-to-left on row two.
+    positions = [
+        (xcols[0], yrows[0]),
+        (xcols[1], yrows[0]),
+        (xcols[2], yrows[0]),
+        (xcols[2], yrows[1]),
+        (xcols[1], yrows[1]),
+        (xcols[0], yrows[1]),
+    ]
+    for i, (title, lines, accent) in enumerate(steps):
+        x, y = positions[i]
+        s += box(x, y, bw, bh, title, lines, accent=accent, rounded=12)
+        s += (f'<circle cx="{x+20}" cy="{y+20}" r="12" fill="{YELLOW}"/>\n'
+              f'<text x="{x+20}" y="{y+24}" fill="{BG}" font-size="11" font-weight="700" '
+              f'text-anchor="middle">{i+1}</text>\n')
 
-    def fbox(x, y, w, label, sub, accent=False):
-        return box(x, y, w, 62, label, [sub] if sub else None, accent=accent, rounded=10)
+    # Every connector stays in the gutter between boxes. Label chips are painted
+    # after each line, so a line can never cut through its text.
+    s += edge(340, 190, 443, 190, "INSERT", mid=(395, 167))
+    s += edge(750, 190, 853, 190, "CDC", mid=(805, 167))
+    s += elbow([(1010, 245), (1010, 338)], "lands here", mid=(1010, 302))
+    s += edge(860, 400, 757, 400, "feeds", mid=(805, 377))
+    s += edge(450, 400, 347, 400, "reads", mid=(395, 377))
 
-    def harrow(x1, x2, y, label):
-        return edge(x1, y, x2, y, label, label_dy=-9)
-
-    x0 = LX + TITLE_W + 10     # where the flow chain starts
-    bw = 216                   # box width
-    gap = 140                  # arrow gap (wide enough for the longest label chip)
-
-    def col(i):
-        return x0 + i*(bw+gap)
-
-    # Lane 1 — SEED (module 01)
-    y = 96; s += lane(y, 96, "Seed", "one-time, module 01")
-    by = y + 17
-    s += fbox(col(0), by, bw, "NYC TLC parquet", "~3.2M rows, public")
-    s += fbox(col(2), by, bw, "ClickHouse service", "nyc_tlc_data.taxi_trips", accent=True)
-    s += harrow(col(0)+bw, col(2)-6, by+31, "url() seed — one statement, module 01")
-
-    # Lane 2 — LIVE CDC (module 03)
-    y = 212; s += lane(y, 110, "Live CDC", "continuous, module 03")
-    by = y + 24
-    s += fbox(col(0), by, bw, "pg-trip-writer", "synthetic trips")
-    s += fbox(col(1), by, bw, "Managed Postgres", "public.realtime_trips")
-    s += fbox(col(2), by, bw, "ClickPipes", "Postgres CDC pipe")
-    s += fbox(col(3), by, bw, "ClickHouse service", "MV → taxi_trips", accent=True)
-    s += harrow(col(0)+bw, col(1)-6, by+31, "INSERT · TLS")
-    s += harrow(col(1)+bw, col(2)-6, by+31, "replication")
-    s += harrow(col(2)+bw, col(3)-6, by+31, "CDC rows ~60s")
-
-    # Lane 3 — READ (modules 02, 04, 08)
-    y = 342; s += lane(y, 176, "Read", "modules 02, 04, 08")
-    by = y + 22
-    s += fbox(col(0), by, bw, "ClickHouse service", "nyc_tlc_data", accent=True)
-    s += fbox(col(1), by, bw, "FastAPI", "safe parameterized SQL")
-    s += fbox(col(2), by, bw, "Ops + Historical", "React dashboards")
-    s += harrow(col(0)+bw, col(1)-6, by+31, "SELECT")
-    s += harrow(col(1)+bw, col(2)-6, by+31, "GET /api/*")
-    # two more consumers off the service (stacked below)
-    by2 = y + 104
-    s += fbox(col(1), by2, bw, "in-app AI chat", "guarded SELECT (module 08)")
-    s += fbox(col(2), by2, bw, "ClickHouse Agents", "RBAC SQL (module 04)")
-    s += elbow([(col(0)+bw/2, by+62), (col(0)+bw/2, by2+31), (col(1)-6, by2+31)], "NL → SQL", mid=(col(0)+bw/2+70, by2+22))
-    s += harrow(col(1)+bw, col(2)-6, by2+31, "RBAC SQL")
-
-    # Lane 4 — OBSERVE (modules 05, 06, 07)
-    y = 538; s += lane(y, 176, "Observe", "modules 05, 06, 07")
-    by = y + 22
-    s += fbox(col(0), by, bw, "backend spans", "clickhouse.query + logs")
-    s += fbox(col(1), by, bw, "stateless OTel forwarder", "local OTLP :4318")
-    s += fbox(col(2), by, bw, "otel db", "in your service")
-    s += fbox(col(3), by, bw, "HyperDX UI", "search, traces, dashboards")
-    s += harrow(col(0)+bw, col(1)-6, by+31, "OTLP")
-    s += harrow(col(1)+bw, col(2)-6, by+31, "write")
-    s += harrow(col(2)+bw, col(3)-6, by+31, "read")
-    by2 = y + 104
-    s += fbox(col(1), by2, bw, "coding agent", "via ClickStack MCP")
-    s += elbow([(col(1)+bw/2, by2), (col(1)+bw/2, by+62)], None)
-    s += (f'<text x="{col(2)-6}" y="{by2+34}" fill="{SUBINK}" font-size="11.5">'
-          f'clickstack_search / save_dashboard / save_alert</text>\n')
+    s += (f'<rect x="40" y="505" width="1120" height="75" rx="12" fill="#1C1C22" '
+          f'stroke="#3A3A45" stroke-width="1.3"/>\n')
+    s += (f'<text x="65" y="535" fill="{YELLOW}" font-size="13" font-weight="700">'
+          f'What the other workshop tools do</text>\n')
+    s += (f'<text x="65" y="560" fill="{SUBINK}" font-size="12.5">'
+          f'ClickStack observes the app · ClickHouse Agents answers data questions · Langfuse traces the chat</text>\n')
     s += "</svg>\n"
     return s
 

--- a/workshops/build_workshop/docs/diagrams/gen_diagrams.py
+++ b/workshops/build_workshop/docs/diagrams/gen_diagrams.py
@@ -20,9 +20,9 @@ MONO      = "Inconsolata, ui-monospace, monospace"
 
 # zone tints (muted, harmonious)
 ZONES = {
-    "laptop": {"fill": "#1B2531", "stroke": "#3E5A78", "label": "PARTICIPANT LAPTOP  ·  the NYC-taxi app runs here"},
-    "cloud":  {"fill": "#211F14", "stroke": YELLOW,    "label": "CLICKHOUSE CLOUD  ·  your trial org (you create all of this)"},
-    "third":  {"fill": "#1E1E22", "stroke": "#54545C", "label": "THIRD-PARTY"},
+    "laptop": {"fill": "#1B2531", "stroke": "#3E5A78", "label": "PARTICIPANT LAPTOP · local app + tools"},
+    "cloud":  {"fill": "#211F14", "stroke": YELLOW,    "label": "CLICKHOUSE CLOUD · your trial org"},
+    "third":  {"fill": "#1E1E22", "stroke": "#54545C", "label": "EXTERNAL SERVICES"},
 }
 
 
@@ -46,21 +46,22 @@ def box(x, y, w, h, title, lines=None, accent=False, rounded=12, fill=BOX_FILL, 
     cx = x + w / 2
     # title
     ty = y + (22 if lines else h/2 + 5)
-    s += (f'<text x="{cx}" y="{ty}" fill="{INK}" font-size="17" font-weight="600" '
+    s += (f'<text x="{cx}" y="{ty}" fill="{INK}" font-size="18" font-weight="600" '
           f'text-anchor="middle">{escape(title)}</text>\n')
     if lines:
         for i, ln in enumerate(lines):
-            s += (f'<text x="{cx}" y="{y+44+i*18}" fill="{SUBINK}" font-size="14" '
+            s += (f'<text x="{cx}" y="{y+44+i*18}" fill="{SUBINK}" font-size="14.5" '
                   f'text-anchor="middle">{escape(ln)}</text>\n')
     return s
 
 
 def zone(x, y, w, h, key):
     z = ZONES[key]
+    label_color = YELLOW if key == "cloud" else SUBINK
     s = (f'<rect x="{x}" y="{y}" width="{w}" height="{h}" rx="16" fill="{z["fill"]}" '
          f'stroke="{z["stroke"]}" stroke-width="1.6" opacity="0.96"/>\n')
-    s += (f'<text x="{x+18}" y="{y+26}" fill="{z["stroke"] if key!="cloud" else YELLOW}" '
-          f'font-size="15" font-weight="700" letter-spacing="0.5">{escape(z["label"])}</text>\n')
+    s += (f'<text x="{x+18}" y="{y+26}" fill="{label_color}" '
+          f'font-size="16" font-weight="700" letter-spacing="0.5">{escape(z["label"])}</text>\n')
     return s
 
 
@@ -169,39 +170,35 @@ def module_flow():
 # ARCHITECTURE  (three simple groups; the data-flow diagram owns sequencing)
 # ===========================================================================
 def architecture():
-    W, H = 1500, 650
+    W, H = 1200, 650
     s = _svg_header(W, H)
     s += (f'<text x="30" y="44" fill="{INK}" font-size="22" font-weight="700">'
           f'ClickHouse BUILD Workshop · Where each component runs</text>\n')
     s += (f'<text x="30" y="70" fill="{SUBINK}" font-size="13.5">'
-          f'Group components by location first. Follow the next diagram for the trip data path.</text>\n')
+          f'Grouped by location; no data direction is implied. Follow the next diagram for the trip path.</text>\n')
 
     # zones
-    s += zone(30, 110, 430, 480, "laptop")
-    s += zone(510, 110, 620, 480, "cloud")
-    s += zone(1180, 110, 290, 480, "third")
+    s += zone(30, 110, 330, 480, "laptop")
+    s += zone(400, 110, 500, 480, "cloud")
+    s += zone(940, 110, 230, 480, "third")
 
     # Participant laptop: application edge and stateless tools only.
-    s += box(60, 165, 370, 78, "Frontend + FastAPI", ["dashboards, chat, and API", "runs with Docker Compose"])
-    s += box(60, 270, 370, 68, "Load generator", ["creates synthetic trip rows"])
-    s += box(60, 365, 370, 68, "OpenTelemetry forwarder", ["sends app telemetry to ClickStack"])
-    s += box(60, 460, 370, 78, "Coding agent + clickhousectl", ["workshop commands, MCP,", "and ClickHouse skills"])
+    s += box(50, 165, 290, 78, "Frontend + FastAPI", ["dashboards, chat, and API", "runs with Docker Compose"])
+    s += box(50, 270, 290, 68, "Load generator", ["creates synthetic trip rows"])
+    s += box(50, 365, 290, 68, "OTel forwarder", ["sends telemetry to ClickStack"])
+    s += box(50, 460, 290, 78, "Coding agent + CLI", ["workshop commands, MCP,", "and ClickHouse skills"])
 
     # ClickHouse Cloud: state, ingestion, observability, and AI surfaces.
-    s += box(540, 165, 560, 88, "ClickHouse service", ["default.realtime_trips lands here", "nyc_tlc_data.taxi_trips powers the app"], accent=True)
-    s += box(540, 285, 265, 78, "Managed Postgres", ["public.realtime_trips"])
-    s += box(835, 285, 265, 78, "ClickPipes", ["streams Postgres changes"])
-    s += box(540, 395, 265, 88, "Managed ClickStack", ["HyperDX traces, logs,", "dashboards, and alerts"])
-    s += box(835, 395, 265, 88, "Agents + remote MCP", ["ask questions and let", "the coding agent use tools"])
+    s += box(425, 165, 450, 88, "ClickHouse service", ["default.realtime_trips lands here", "nyc_tlc_data.taxi_trips powers the app"], accent=True)
+    s += box(425, 285, 215, 78, "Managed Postgres", ["public.realtime_trips"])
+    s += box(660, 285, 215, 78, "ClickPipes", ["streams Postgres changes"])
+    s += box(425, 395, 215, 88, "Managed ClickStack", ["HyperDX traces, logs,", "dashboards, and alerts"])
+    s += box(660, 395, 215, 88, "Agents + MCP", ["data questions and", "coding-agent tools"])
 
     # External services used by the app, kept separate from workshop data storage.
-    s += box(1210, 175, 230, 82, "OpenAI API", ["chat completions"])
-    s += box(1210, 290, 230, 82, "Langfuse Cloud", ["chat traces and cost"])
-    s += box(1210, 405, 230, 92, "NYC TLC dataset", ["one-time historical", "seed source"])
-
-    # Only zone-level relationships. Detailed sequencing belongs in data_flow().
-    s += edge(460, 565, 510, 565, "uses", mid=(485, 548))
-    s += edge(1130, 565, 1180, 565, "calls", mid=(1155, 548))
+    s += box(960, 175, 190, 82, "OpenAI API", ["chat completions"])
+    s += box(960, 290, 190, 82, "Langfuse Cloud", ["chat traces and cost"])
+    s += box(960, 405, 190, 92, "NYC TLC dataset", ["one-time historical", "seed source"])
 
     s += "</svg>\n"
     return s
@@ -303,7 +300,7 @@ def data_flow():
     s += (f'<text x="30" y="44" fill="{INK}" font-size="22" font-weight="700">'
           f'ClickHouse BUILD Workshop · A trip\'s path</text>\n')
     s += (f'<text x="30" y="70" fill="{SUBINK}" font-size="13.5">'
-          f'Read left to right: generate a trip, stream it into ClickHouse, then show it in the app.</text>\n')
+          f'Follow steps 1–6: across the top, then back across the bottom.</text>\n')
 
     xcols, yrows, bw, bh = [40, 450, 860], [135, 345], 300, 110
     steps = [

--- a/workshops/build_workshop/docs/diagrams/gen_diagrams.py
+++ b/workshops/build_workshop/docs/diagrams/gen_diagrams.py
@@ -106,7 +106,6 @@ def module_flow():
         ("04 ClickHouse Agents", "10 min", "conversational BI", "over your taxi data"),
         ("05 ClickStack", "15 min", "OTel overlay: traces", "+ logs in HyperDX"),
         ("06 AI SRE", "15 min", "agent + ClickStack MCP", "builds dashboard + alert"),
-        ("06b Hosted LibreChat", "optional · 15 min", "remote ClickStack + GitHub MCP", "chat-native SRE workflow"),
         ("07 Test, fail, and fix", "20 min", "inject a fault, diagnose", "with the AI SRE, fix it"),
         ("08 Chat + Langfuse", "15 min", "in-app AI chat,", "every turn traced"),
         ("09 Wrap-up", "10 min", "running prototype,", "take it home"),
@@ -122,7 +121,7 @@ def module_flow():
     s += (f'<text x="{gx}" y="{gy+8}" fill="{INK}" font-size="20" font-weight="700">'
           f'ClickHouse BUILD Workshop · Module flow</text>\n')
     s += (f'<text x="{gx}" y="{gy+30}" fill="{SUBINK}" font-size="13">'
-          f'~2h30 core + optional 06b · only module 07 switches to a fault branch</text>\n')
+          f'~2h30 hands-on · only module 07 switches to a fault branch</text>\n')
 
     top = gy + 52
     pos = {}
@@ -203,7 +202,6 @@ def architecture():
     s += box(1315, 195, 330, 74, "Langfuse Cloud", ["chat traces, sessions, cost"])
     s += box(1315, 300, 330, 74, "OpenAI API", ["chat completions (gpt-5.4-mini)"])
     s += box(1315, 410, 330, 88, "NYC TLC dataset", ["public parquet; read once by the", "module 01 seed. Data source only."])
-    s += box(1315, 530, 330, 74, "Hosted LibreChat", ["optional SRE chat · remote MCP"])
 
     # --- edges (laptop internal) ---
     s += edge(287, 252, 287, 300, "/api proxy", label_dx=42)

--- a/workshops/build_workshop/docs/diagrams/workshop-architecture.svg
+++ b/workshops/build_workshop/docs/diagrams/workshop-architecture.svg
@@ -1,60 +1,54 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1500" height="650" viewBox="0 0 1500 650" font-family="Inter, -apple-system, Segoe UI, Roboto, sans-serif">
-<rect x="0" y="0" width="1500" height="650" fill="#17171A"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="650" viewBox="0 0 1200 650" font-family="Inter, -apple-system, Segoe UI, Roboto, sans-serif">
+<rect x="0" y="0" width="1200" height="650" fill="#17171A"/>
 <defs><marker id="arrow" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L7,3 L0,6 Z" fill="#7E858E"/></marker></defs>
 <text x="30" y="44" fill="#EDEDED" font-size="22" font-weight="700">ClickHouse BUILD Workshop · Where each component runs</text>
-<text x="30" y="70" fill="#B7BCC2" font-size="13.5">Group components by location first. Follow the next diagram for the trip data path.</text>
-<rect x="30" y="110" width="430" height="480" rx="16" fill="#1B2531" stroke="#3E5A78" stroke-width="1.6" opacity="0.96"/>
-<text x="48" y="136" fill="#3E5A78" font-size="15" font-weight="700" letter-spacing="0.5">PARTICIPANT LAPTOP  ·  the NYC-taxi app runs here</text>
-<rect x="510" y="110" width="620" height="480" rx="16" fill="#211F14" stroke="#FAFF69" stroke-width="1.6" opacity="0.96"/>
-<text x="528" y="136" fill="#FAFF69" font-size="15" font-weight="700" letter-spacing="0.5">CLICKHOUSE CLOUD  ·  your trial org (you create all of this)</text>
-<rect x="1180" y="110" width="290" height="480" rx="16" fill="#1E1E22" stroke="#54545C" stroke-width="1.6" opacity="0.96"/>
-<text x="1198" y="136" fill="#54545C" font-size="15" font-weight="700" letter-spacing="0.5">THIRD-PARTY</text>
-<rect x="60" y="165" width="370" height="78" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="245.0" y="187" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Frontend + FastAPI</text>
-<text x="245.0" y="209" fill="#B7BCC2" font-size="14" text-anchor="middle">dashboards, chat, and API</text>
-<text x="245.0" y="227" fill="#B7BCC2" font-size="14" text-anchor="middle">runs with Docker Compose</text>
-<rect x="60" y="270" width="370" height="68" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="245.0" y="292" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Load generator</text>
-<text x="245.0" y="314" fill="#B7BCC2" font-size="14" text-anchor="middle">creates synthetic trip rows</text>
-<rect x="60" y="365" width="370" height="68" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="245.0" y="387" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">OpenTelemetry forwarder</text>
-<text x="245.0" y="409" fill="#B7BCC2" font-size="14" text-anchor="middle">sends app telemetry to ClickStack</text>
-<rect x="60" y="460" width="370" height="78" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="245.0" y="482" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Coding agent + clickhousectl</text>
-<text x="245.0" y="504" fill="#B7BCC2" font-size="14" text-anchor="middle">workshop commands, MCP,</text>
-<text x="245.0" y="522" fill="#B7BCC2" font-size="14" text-anchor="middle">and ClickHouse skills</text>
-<rect x="540" y="165" width="560" height="88" rx="12" fill="#26262B" stroke="#FAFF69" stroke-width="2"/>
-<text x="820.0" y="187" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">ClickHouse service</text>
-<text x="820.0" y="209" fill="#B7BCC2" font-size="14" text-anchor="middle">default.realtime_trips lands here</text>
-<text x="820.0" y="227" fill="#B7BCC2" font-size="14" text-anchor="middle">nyc_tlc_data.taxi_trips powers the app</text>
-<rect x="540" y="285" width="265" height="78" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="672.5" y="307" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Managed Postgres</text>
-<text x="672.5" y="329" fill="#B7BCC2" font-size="14" text-anchor="middle">public.realtime_trips</text>
-<rect x="835" y="285" width="265" height="78" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="967.5" y="307" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">ClickPipes</text>
-<text x="967.5" y="329" fill="#B7BCC2" font-size="14" text-anchor="middle">streams Postgres changes</text>
-<rect x="540" y="395" width="265" height="88" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="672.5" y="417" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Managed ClickStack</text>
-<text x="672.5" y="439" fill="#B7BCC2" font-size="14" text-anchor="middle">HyperDX traces, logs,</text>
-<text x="672.5" y="457" fill="#B7BCC2" font-size="14" text-anchor="middle">dashboards, and alerts</text>
-<rect x="835" y="395" width="265" height="88" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="967.5" y="417" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Agents + remote MCP</text>
-<text x="967.5" y="439" fill="#B7BCC2" font-size="14" text-anchor="middle">ask questions and let</text>
-<text x="967.5" y="457" fill="#B7BCC2" font-size="14" text-anchor="middle">the coding agent use tools</text>
-<rect x="1210" y="175" width="230" height="82" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1325.0" y="197" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">OpenAI API</text>
-<text x="1325.0" y="219" fill="#B7BCC2" font-size="14" text-anchor="middle">chat completions</text>
-<rect x="1210" y="290" width="230" height="82" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1325.0" y="312" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Langfuse Cloud</text>
-<text x="1325.0" y="334" fill="#B7BCC2" font-size="14" text-anchor="middle">chat traces and cost</text>
-<rect x="1210" y="405" width="230" height="92" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1325.0" y="427" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">NYC TLC dataset</text>
-<text x="1325.0" y="449" fill="#B7BCC2" font-size="14" text-anchor="middle">one-time historical</text>
-<text x="1325.0" y="467" fill="#B7BCC2" font-size="14" text-anchor="middle">seed source</text>
-<path d="M460,565 L510,565" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="465.6" y="534" width="38.8" height="20" rx="4" fill="#17171A"/>
-<text x="485" y="548" fill="#B7BCC2" font-size="12.5" text-anchor="middle">uses</text>
-<path d="M1130,565 L1180,565" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="1132.0" y="534" width="46.0" height="20" rx="4" fill="#17171A"/>
-<text x="1155" y="548" fill="#B7BCC2" font-size="12.5" text-anchor="middle">calls</text>
+<text x="30" y="70" fill="#B7BCC2" font-size="13.5">Grouped by location; no data direction is implied. Follow the next diagram for the trip path.</text>
+<rect x="30" y="110" width="330" height="480" rx="16" fill="#1B2531" stroke="#3E5A78" stroke-width="1.6" opacity="0.96"/>
+<text x="48" y="136" fill="#B7BCC2" font-size="16" font-weight="700" letter-spacing="0.5">PARTICIPANT LAPTOP · local app + tools</text>
+<rect x="400" y="110" width="500" height="480" rx="16" fill="#211F14" stroke="#FAFF69" stroke-width="1.6" opacity="0.96"/>
+<text x="418" y="136" fill="#FAFF69" font-size="16" font-weight="700" letter-spacing="0.5">CLICKHOUSE CLOUD · your trial org</text>
+<rect x="940" y="110" width="230" height="480" rx="16" fill="#1E1E22" stroke="#54545C" stroke-width="1.6" opacity="0.96"/>
+<text x="958" y="136" fill="#B7BCC2" font-size="16" font-weight="700" letter-spacing="0.5">EXTERNAL SERVICES</text>
+<rect x="50" y="165" width="290" height="78" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="195.0" y="187" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">Frontend + FastAPI</text>
+<text x="195.0" y="209" fill="#B7BCC2" font-size="14.5" text-anchor="middle">dashboards, chat, and API</text>
+<text x="195.0" y="227" fill="#B7BCC2" font-size="14.5" text-anchor="middle">runs with Docker Compose</text>
+<rect x="50" y="270" width="290" height="68" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="195.0" y="292" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">Load generator</text>
+<text x="195.0" y="314" fill="#B7BCC2" font-size="14.5" text-anchor="middle">creates synthetic trip rows</text>
+<rect x="50" y="365" width="290" height="68" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="195.0" y="387" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">OTel forwarder</text>
+<text x="195.0" y="409" fill="#B7BCC2" font-size="14.5" text-anchor="middle">sends telemetry to ClickStack</text>
+<rect x="50" y="460" width="290" height="78" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="195.0" y="482" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">Coding agent + CLI</text>
+<text x="195.0" y="504" fill="#B7BCC2" font-size="14.5" text-anchor="middle">workshop commands, MCP,</text>
+<text x="195.0" y="522" fill="#B7BCC2" font-size="14.5" text-anchor="middle">and ClickHouse skills</text>
+<rect x="425" y="165" width="450" height="88" rx="12" fill="#26262B" stroke="#FAFF69" stroke-width="2"/>
+<text x="650.0" y="187" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">ClickHouse service</text>
+<text x="650.0" y="209" fill="#B7BCC2" font-size="14.5" text-anchor="middle">default.realtime_trips lands here</text>
+<text x="650.0" y="227" fill="#B7BCC2" font-size="14.5" text-anchor="middle">nyc_tlc_data.taxi_trips powers the app</text>
+<rect x="425" y="285" width="215" height="78" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="532.5" y="307" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">Managed Postgres</text>
+<text x="532.5" y="329" fill="#B7BCC2" font-size="14.5" text-anchor="middle">public.realtime_trips</text>
+<rect x="660" y="285" width="215" height="78" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="767.5" y="307" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">ClickPipes</text>
+<text x="767.5" y="329" fill="#B7BCC2" font-size="14.5" text-anchor="middle">streams Postgres changes</text>
+<rect x="425" y="395" width="215" height="88" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="532.5" y="417" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">Managed ClickStack</text>
+<text x="532.5" y="439" fill="#B7BCC2" font-size="14.5" text-anchor="middle">HyperDX traces, logs,</text>
+<text x="532.5" y="457" fill="#B7BCC2" font-size="14.5" text-anchor="middle">dashboards, and alerts</text>
+<rect x="660" y="395" width="215" height="88" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="767.5" y="417" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">Agents + MCP</text>
+<text x="767.5" y="439" fill="#B7BCC2" font-size="14.5" text-anchor="middle">data questions and</text>
+<text x="767.5" y="457" fill="#B7BCC2" font-size="14.5" text-anchor="middle">coding-agent tools</text>
+<rect x="960" y="175" width="190" height="82" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="1055.0" y="197" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">OpenAI API</text>
+<text x="1055.0" y="219" fill="#B7BCC2" font-size="14.5" text-anchor="middle">chat completions</text>
+<rect x="960" y="290" width="190" height="82" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="1055.0" y="312" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">Langfuse Cloud</text>
+<text x="1055.0" y="334" fill="#B7BCC2" font-size="14.5" text-anchor="middle">chat traces and cost</text>
+<rect x="960" y="405" width="190" height="92" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="1055.0" y="427" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">NYC TLC dataset</text>
+<text x="1055.0" y="449" fill="#B7BCC2" font-size="14.5" text-anchor="middle">one-time historical</text>
+<text x="1055.0" y="467" fill="#B7BCC2" font-size="14.5" text-anchor="middle">seed source</text>
 </svg>

--- a/workshops/build_workshop/docs/diagrams/workshop-architecture.svg
+++ b/workshops/build_workshop/docs/diagrams/workshop-architecture.svg
@@ -1,104 +1,60 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1700" height="1000" viewBox="0 0 1700 1000" font-family="Inter, -apple-system, Segoe UI, Roboto, sans-serif">
-<rect x="0" y="0" width="1700" height="1000" fill="#17171A"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="1500" height="650" viewBox="0 0 1500 650" font-family="Inter, -apple-system, Segoe UI, Roboto, sans-serif">
+<rect x="0" y="0" width="1500" height="650" fill="#17171A"/>
 <defs><marker id="arrow" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L7,3 L0,6 Z" fill="#7E858E"/></marker></defs>
-<text x="30" y="44" fill="#EDEDED" font-size="22" font-weight="700">ClickHouse BUILD Workshop · Architecture (target end state)</text>
-<text x="30" y="70" fill="#B7BCC2" font-size="13.5">App-side components run locally; stateful data services run in ClickHouse Cloud. Dashed lines are control/OAuth; solid lines are data.</text>
-<rect x="30" y="135" width="515" height="700" rx="16" fill="#1B2531" stroke="#3E5A78" stroke-width="1.6" opacity="0.96"/>
-<text x="48" y="161" fill="#3E5A78" font-size="13" font-weight="700" letter-spacing="0.5">PARTICIPANT LAPTOP  ·  the NYC-taxi app runs here</text>
-<rect x="590" y="135" width="650" height="760" rx="16" fill="#211F14" stroke="#FAFF69" stroke-width="1.6" opacity="0.96"/>
-<text x="608" y="161" fill="#FAFF69" font-size="13" font-weight="700" letter-spacing="0.5">CLICKHOUSE CLOUD  ·  your trial org (you create all of this)</text>
-<rect x="1290" y="135" width="380" height="560" rx="16" fill="#1E1E22" stroke="#54545C" stroke-width="1.6" opacity="0.96"/>
-<text x="1308" y="161" fill="#54545C" font-size="13" font-weight="700" letter-spacing="0.5">THIRD-PARTY</text>
-<rect x="60" y="190" width="455" height="62" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="287.5" y="212" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">frontend</text>
-<text x="287.5" y="234" fill="#B7BCC2" font-size="12.5" text-anchor="middle">React SPA · nginx :8080</text>
-<text x="287.5" y="252" fill="#B7BCC2" font-size="12.5" text-anchor="middle">Ops + Historical dashboards, chat</text>
-<rect x="60" y="300" width="455" height="62" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="287.5" y="322" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">backend</text>
-<text x="287.5" y="344" fill="#B7BCC2" font-size="12.5" text-anchor="middle">FastAPI :8000</text>
-<text x="287.5" y="362" fill="#B7BCC2" font-size="12.5" text-anchor="middle">analytics API + /api/chat (NL-to-SQL)</text>
-<rect x="60" y="410" width="455" height="56" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="287.5" y="432" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">otel-collector</text>
-<text x="287.5" y="454" fill="#B7BCC2" font-size="12.5" text-anchor="middle">ClickStack overlay (module 05)</text>
-<rect x="60" y="520" width="455" height="62" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="287.5" y="542" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">pg-trip-writer</text>
-<text x="287.5" y="564" fill="#B7BCC2" font-size="12.5" text-anchor="middle">synthetic trips; creates the CDC</text>
-<text x="287.5" y="582" fill="#B7BCC2" font-size="12.5" text-anchor="middle">table + publication on first run</text>
-<rect x="60" y="660" width="455" height="62" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="287.5" y="682" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">coding agent + clickhousectl</text>
-<text x="287.5" y="704" fill="#B7BCC2" font-size="12.5" text-anchor="middle">Claude Code / Cursor / Codex</text>
-<text x="287.5" y="722" fill="#B7BCC2" font-size="12.5" text-anchor="middle">+ ClickHouse skills + docs llms.txt</text>
-<rect x="620" y="185" width="590" height="96" rx="12" fill="#26262B" stroke="#FAFF69" stroke-width="2"/>
-<text x="915.0" y="207" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">ClickHouse service  :8443 TLS</text>
-<text x="915.0" y="229" fill="#B7BCC2" font-size="12.5" text-anchor="middle">nyc_tlc_data (taxi_trips, taxi_zones,</text>
-<text x="915.0" y="247" fill="#B7BCC2" font-size="12.5" text-anchor="middle">views, CDC MV)   +   otel db (logs, traces)</text>
-<rect x="620" y="330" width="280" height="88" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="760.0" y="352" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">ClickPipes</text>
-<text x="760.0" y="374" fill="#B7BCC2" font-size="12.5" text-anchor="middle">Postgres CDC pipe</text>
-<text x="760.0" y="392" fill="#B7BCC2" font-size="12.5" text-anchor="middle">snapshot + stream (~60s)</text>
-<rect x="930" y="330" width="280" height="88" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1070.0" y="352" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">Managed ClickStack / HyperDX</text>
-<text x="1070.0" y="374" fill="#B7BCC2" font-size="12.5" text-anchor="middle">traces + logs UI</text>
-<text x="1070.0" y="392" fill="#B7BCC2" font-size="12.5" text-anchor="middle">module 05</text>
-<rect x="620" y="500" width="590" height="82" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="915.0" y="522" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">Postgres managed by ClickHouse  :5432 TLS</text>
-<text x="915.0" y="544" fill="#B7BCC2" font-size="12.5" text-anchor="middle">you create it with clickhousectl (module 03) · public.realtime_trips + pub_taxi</text>
-<rect x="620" y="628" width="280" height="74" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="760.0" y="650" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">Remote MCP</text>
-<text x="760.0" y="672" fill="#B7BCC2" font-size="12.5" text-anchor="middle">/mcp + /clickstack (OAuth)</text>
-<rect x="930" y="628" width="280" height="74" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1070.0" y="650" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">ClickHouse Agents</text>
-<text x="1070.0" y="672" fill="#B7BCC2" font-size="12.5" text-anchor="middle">ai.clickhouse.cloud (module 04)</text>
-<rect x="620" y="748" width="590" height="60" rx="12" fill="#1C1B14" stroke="#4C4C55" stroke-width="1.3" stroke-dasharray="5 4"/>
-<text x="915.0" y="770" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">Instructor cloud fallback only</text>
-<text x="915.0" y="792" fill="#B7BCC2" font-size="12.5" text-anchor="middle">managed Postgres pool when a trial org cannot create one</text>
-<rect x="1315" y="195" width="330" height="74" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1480.0" y="217" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">Langfuse Cloud</text>
-<text x="1480.0" y="239" fill="#B7BCC2" font-size="12.5" text-anchor="middle">chat traces, sessions, cost</text>
-<rect x="1315" y="300" width="330" height="74" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1480.0" y="322" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">OpenAI API</text>
-<text x="1480.0" y="344" fill="#B7BCC2" font-size="12.5" text-anchor="middle">chat completions (gpt-5.4-mini)</text>
-<rect x="1315" y="410" width="330" height="88" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1480.0" y="432" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">NYC TLC dataset</text>
-<text x="1480.0" y="454" fill="#B7BCC2" font-size="12.5" text-anchor="middle">public parquet; read once by the</text>
-<text x="1480.0" y="472" fill="#B7BCC2" font-size="12.5" text-anchor="middle">module 01 seed. Data source only.</text>
-<path d="M287,252 L287,300" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="288.0" y="257.0" width="82.0" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="329.0" y="270.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">/api proxy</text>
-<path d="M180,362 L180,410" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="126.6" y="367.0" width="38.8" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="146.0" y="380.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">OTLP</text>
-<path d="M515,331 L560,331 L560,250 L620,250" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="508.0" y="287" width="118.0" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="567" y="300" fill="#B7BCC2" font-size="11.5" text-anchor="middle">SQL · TLS :8443</text>
-<path d="M515,438 L585,438 L585,262 L620,262" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="522.4" y="387" width="125.2" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="585" y="400" fill="#B7BCC2" font-size="11.5" text-anchor="middle">traces → otel db</text>
-<path d="M515,545 L620,541" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="497.7" y="522.0" width="139.6" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="567.5" y="535.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">INSERT trips · TLS</text>
-<path d="M515,690 L620,665" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="522.9" y="656.5" width="89.2" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="567.5" y="669.5" fill="#B7BCC2" font-size="11.5" text-anchor="middle">MCP · OAuth</text>
-<path d="M760,500 L760,418" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="686.6" y="442.0" width="146.8" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="760.0" y="455.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">logical replication</text>
-<path d="M760,330 L760,281" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="708.2" y="288.5" width="103.60000000000001" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="760.0" y="301.5" fill="#B7BCC2" font-size="11.5" text-anchor="middle">CDC rows ~60s</text>
-<path d="M1070,330 L1070,281" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="1018.2" y="288.5" width="103.60000000000001" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="1070.0" y="301.5" fill="#B7BCC2" font-size="11.5" text-anchor="middle">reads otel db</text>
-<path d="M1070,628 L1215,628 L1215,235 L1210,235" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="1181.2" y="457" width="67.6" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="1215" y="470" fill="#B7BCC2" font-size="11.5" text-anchor="middle">RBAC SQL</text>
-<path d="M360,300 L360,118 L1480,118 L1480,300" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="887.4" y="99" width="125.2" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="950" y="112" fill="#B7BCC2" font-size="11.5" text-anchor="middle">chat completions</text>
-<path d="M330,300 L330,96 L1430,96 L1430,195" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="661.4" y="77" width="197.20000000000002" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="760" y="90" fill="#B7BCC2" font-size="11.5" text-anchor="middle">chat traces (Langfuse SDK)</text>
-<path d="M1315,452 L1262,452 L1262,215 L1210,215" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="1221.0" y="292" width="82.0" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="1262" y="305" fill="#B7BCC2" font-size="11.5" text-anchor="middle">url() seed</text>
+<text x="30" y="44" fill="#EDEDED" font-size="22" font-weight="700">ClickHouse BUILD Workshop · Where each component runs</text>
+<text x="30" y="70" fill="#B7BCC2" font-size="13.5">Group components by location first. Follow the next diagram for the trip data path.</text>
+<rect x="30" y="110" width="430" height="480" rx="16" fill="#1B2531" stroke="#3E5A78" stroke-width="1.6" opacity="0.96"/>
+<text x="48" y="136" fill="#3E5A78" font-size="15" font-weight="700" letter-spacing="0.5">PARTICIPANT LAPTOP  ·  the NYC-taxi app runs here</text>
+<rect x="510" y="110" width="620" height="480" rx="16" fill="#211F14" stroke="#FAFF69" stroke-width="1.6" opacity="0.96"/>
+<text x="528" y="136" fill="#FAFF69" font-size="15" font-weight="700" letter-spacing="0.5">CLICKHOUSE CLOUD  ·  your trial org (you create all of this)</text>
+<rect x="1180" y="110" width="290" height="480" rx="16" fill="#1E1E22" stroke="#54545C" stroke-width="1.6" opacity="0.96"/>
+<text x="1198" y="136" fill="#54545C" font-size="15" font-weight="700" letter-spacing="0.5">THIRD-PARTY</text>
+<rect x="60" y="165" width="370" height="78" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="245.0" y="187" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Frontend + FastAPI</text>
+<text x="245.0" y="209" fill="#B7BCC2" font-size="14" text-anchor="middle">dashboards, chat, and API</text>
+<text x="245.0" y="227" fill="#B7BCC2" font-size="14" text-anchor="middle">runs with Docker Compose</text>
+<rect x="60" y="270" width="370" height="68" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="245.0" y="292" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Load generator</text>
+<text x="245.0" y="314" fill="#B7BCC2" font-size="14" text-anchor="middle">creates synthetic trip rows</text>
+<rect x="60" y="365" width="370" height="68" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="245.0" y="387" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">OpenTelemetry forwarder</text>
+<text x="245.0" y="409" fill="#B7BCC2" font-size="14" text-anchor="middle">sends app telemetry to ClickStack</text>
+<rect x="60" y="460" width="370" height="78" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="245.0" y="482" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Coding agent + clickhousectl</text>
+<text x="245.0" y="504" fill="#B7BCC2" font-size="14" text-anchor="middle">workshop commands, MCP,</text>
+<text x="245.0" y="522" fill="#B7BCC2" font-size="14" text-anchor="middle">and ClickHouse skills</text>
+<rect x="540" y="165" width="560" height="88" rx="12" fill="#26262B" stroke="#FAFF69" stroke-width="2"/>
+<text x="820.0" y="187" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">ClickHouse service</text>
+<text x="820.0" y="209" fill="#B7BCC2" font-size="14" text-anchor="middle">default.realtime_trips lands here</text>
+<text x="820.0" y="227" fill="#B7BCC2" font-size="14" text-anchor="middle">nyc_tlc_data.taxi_trips powers the app</text>
+<rect x="540" y="285" width="265" height="78" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="672.5" y="307" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Managed Postgres</text>
+<text x="672.5" y="329" fill="#B7BCC2" font-size="14" text-anchor="middle">public.realtime_trips</text>
+<rect x="835" y="285" width="265" height="78" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="967.5" y="307" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">ClickPipes</text>
+<text x="967.5" y="329" fill="#B7BCC2" font-size="14" text-anchor="middle">streams Postgres changes</text>
+<rect x="540" y="395" width="265" height="88" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="672.5" y="417" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Managed ClickStack</text>
+<text x="672.5" y="439" fill="#B7BCC2" font-size="14" text-anchor="middle">HyperDX traces, logs,</text>
+<text x="672.5" y="457" fill="#B7BCC2" font-size="14" text-anchor="middle">dashboards, and alerts</text>
+<rect x="835" y="395" width="265" height="88" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="967.5" y="417" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Agents + remote MCP</text>
+<text x="967.5" y="439" fill="#B7BCC2" font-size="14" text-anchor="middle">ask questions and let</text>
+<text x="967.5" y="457" fill="#B7BCC2" font-size="14" text-anchor="middle">the coding agent use tools</text>
+<rect x="1210" y="175" width="230" height="82" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="1325.0" y="197" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">OpenAI API</text>
+<text x="1325.0" y="219" fill="#B7BCC2" font-size="14" text-anchor="middle">chat completions</text>
+<rect x="1210" y="290" width="230" height="82" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="1325.0" y="312" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Langfuse Cloud</text>
+<text x="1325.0" y="334" fill="#B7BCC2" font-size="14" text-anchor="middle">chat traces and cost</text>
+<rect x="1210" y="405" width="230" height="92" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="1325.0" y="427" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">NYC TLC dataset</text>
+<text x="1325.0" y="449" fill="#B7BCC2" font-size="14" text-anchor="middle">one-time historical</text>
+<text x="1325.0" y="467" fill="#B7BCC2" font-size="14" text-anchor="middle">seed source</text>
+<path d="M460,565 L510,565" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
+<rect x="465.6" y="534" width="38.8" height="20" rx="4" fill="#17171A"/>
+<text x="485" y="548" fill="#B7BCC2" font-size="12.5" text-anchor="middle">uses</text>
+<path d="M1130,565 L1180,565" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
+<rect x="1132.0" y="534" width="46.0" height="20" rx="4" fill="#17171A"/>
+<text x="1155" y="548" fill="#B7BCC2" font-size="12.5" text-anchor="middle">calls</text>
 </svg>

--- a/workshops/build_workshop/docs/diagrams/workshop-architecture.svg
+++ b/workshops/build_workshop/docs/diagrams/workshop-architecture.svg
@@ -62,9 +62,6 @@
 <text x="1480.0" y="432" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">NYC TLC dataset</text>
 <text x="1480.0" y="454" fill="#B7BCC2" font-size="12.5" text-anchor="middle">public parquet; read once by the</text>
 <text x="1480.0" y="472" fill="#B7BCC2" font-size="12.5" text-anchor="middle">module 01 seed. Data source only.</text>
-<rect x="1315" y="530" width="330" height="74" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1480.0" y="552" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">Hosted LibreChat</text>
-<text x="1480.0" y="574" fill="#B7BCC2" font-size="12.5" text-anchor="middle">optional SRE chat · remote MCP</text>
 <path d="M287,252 L287,300" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
 <rect x="288.0" y="257.0" width="82.0" height="18" rx="4" fill="#17171A" opacity="0.92"/>
 <text x="329.0" y="270.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">/api proxy</text>

--- a/workshops/build_workshop/docs/diagrams/workshop-data-flow.svg
+++ b/workshops/build_workshop/docs/diagrams/workshop-data-flow.svg
@@ -1,105 +1,60 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1560" height="900" viewBox="0 0 1560 900" font-family="Inter, -apple-system, Segoe UI, Roboto, sans-serif">
-<rect x="0" y="0" width="1560" height="900" fill="#17171A"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="620" viewBox="0 0 1200 620" font-family="Inter, -apple-system, Segoe UI, Roboto, sans-serif">
+<rect x="0" y="0" width="1200" height="620" fill="#17171A"/>
 <defs><marker id="arrow" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L7,3 L0,6 Z" fill="#7E858E"/></marker></defs>
-<text x="30" y="44" fill="#EDEDED" font-size="22" font-weight="700">ClickHouse BUILD Workshop · Data flow</text>
-<text x="30" y="70" fill="#B7BCC2" font-size="13.5">How a row moves: seeded once, streamed continuously, then read and observed — all through your ClickHouse service.</text>
-<rect x="30" y="96" width="1500" height="96" rx="14" fill="#1C1C22" stroke="#3A3A45" stroke-width="1.3"/>
-<rect x="30" y="96" width="6" height="96" rx="3" fill="#FAFF69"/>
-<text x="52" y="126" fill="#EDEDED" font-size="14.5" font-weight="700">Seed</text>
-<text x="52" y="148" fill="#B7BCC2" font-size="11">one-time, module 01</text>
-<rect x="216" y="113" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="324.0" y="135" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">NYC TLC parquet</text>
-<text x="324.0" y="157" fill="#B7BCC2" font-size="12.5" text-anchor="middle">~3.2M rows, public</text>
-<rect x="928" y="113" width="216" height="62" rx="10" fill="#26262B" stroke="#FAFF69" stroke-width="2"/>
-<text x="1036.0" y="135" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">ClickHouse service</text>
-<text x="1036.0" y="157" fill="#B7BCC2" font-size="12.5" text-anchor="middle">nyc_tlc_data.taxi_trips</text>
-<path d="M432,144 L922,144" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="538.8" y="122.0" width="276.40000000000003" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="677.0" y="135.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">url() seed — one statement, module 01</text>
-<rect x="30" y="212" width="1500" height="110" rx="14" fill="#1C1C22" stroke="#3A3A45" stroke-width="1.3"/>
-<rect x="30" y="212" width="6" height="110" rx="3" fill="#FAFF69"/>
-<text x="52" y="242" fill="#EDEDED" font-size="14.5" font-weight="700">Live CDC</text>
-<text x="52" y="264" fill="#B7BCC2" font-size="11">continuous, module 03</text>
-<rect x="216" y="236" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="324.0" y="258" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">pg-trip-writer</text>
-<text x="324.0" y="280" fill="#B7BCC2" font-size="12.5" text-anchor="middle">synthetic trips</text>
-<rect x="572" y="236" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="680.0" y="258" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">Managed Postgres</text>
-<text x="680.0" y="280" fill="#B7BCC2" font-size="12.5" text-anchor="middle">public.realtime_trips</text>
-<rect x="928" y="236" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1036.0" y="258" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">ClickPipes</text>
-<text x="1036.0" y="280" fill="#B7BCC2" font-size="12.5" text-anchor="middle">Postgres CDC pipe</text>
-<rect x="1284" y="236" width="216" height="62" rx="10" fill="#26262B" stroke="#FAFF69" stroke-width="2"/>
-<text x="1392.0" y="258" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">ClickHouse service</text>
-<text x="1392.0" y="280" fill="#B7BCC2" font-size="12.5" text-anchor="middle">MV → taxi_trips</text>
-<path d="M432,267 L566,267" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="450.8" y="245.0" width="96.4" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="499.0" y="258.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">INSERT · TLS</text>
-<path d="M788,267 L922,267" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="810.4" y="245.0" width="89.2" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="855.0" y="258.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">replication</text>
-<path d="M1144,267 L1278,267" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="1159.2" y="245.0" width="103.60000000000001" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="1211.0" y="258.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">CDC rows ~60s</text>
-<rect x="30" y="342" width="1500" height="176" rx="14" fill="#1C1C22" stroke="#3A3A45" stroke-width="1.3"/>
-<rect x="30" y="342" width="6" height="176" rx="3" fill="#FAFF69"/>
-<text x="52" y="372" fill="#EDEDED" font-size="14.5" font-weight="700">Read</text>
-<text x="52" y="394" fill="#B7BCC2" font-size="11">modules 02, 04, 08</text>
-<rect x="216" y="364" width="216" height="62" rx="10" fill="#26262B" stroke="#FAFF69" stroke-width="2"/>
-<text x="324.0" y="386" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">ClickHouse service</text>
-<text x="324.0" y="408" fill="#B7BCC2" font-size="12.5" text-anchor="middle">nyc_tlc_data</text>
-<rect x="572" y="364" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="680.0" y="386" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">FastAPI</text>
-<text x="680.0" y="408" fill="#B7BCC2" font-size="12.5" text-anchor="middle">safe parameterized SQL</text>
-<rect x="928" y="364" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1036.0" y="386" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">Ops + Historical</text>
-<text x="1036.0" y="408" fill="#B7BCC2" font-size="12.5" text-anchor="middle">React dashboards</text>
-<path d="M432,395 L566,395" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="472.4" y="373.0" width="53.2" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="499.0" y="386.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">SELECT</text>
-<path d="M788,395 L922,395" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="814.0" y="373.0" width="82.0" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="855.0" y="386.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">GET /api/*</text>
-<rect x="572" y="446" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="680.0" y="468" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">in-app AI chat</text>
-<text x="680.0" y="490" fill="#B7BCC2" font-size="12.5" text-anchor="middle">guarded SELECT (module 08)</text>
-<rect x="928" y="446" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1036.0" y="468" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">ClickHouse Agents</text>
-<text x="1036.0" y="490" fill="#B7BCC2" font-size="12.5" text-anchor="middle">RBAC SQL (module 04)</text>
-<path d="M324.0,426 L324.0,477 L566,477" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="360.2" y="455" width="67.6" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="394.0" y="468" fill="#B7BCC2" font-size="11.5" text-anchor="middle">NL → SQL</text>
-<path d="M788,477 L922,477" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="821.2" y="455.0" width="67.6" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="855.0" y="468.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">RBAC SQL</text>
-<rect x="30" y="538" width="1500" height="176" rx="14" fill="#1C1C22" stroke="#3A3A45" stroke-width="1.3"/>
-<rect x="30" y="538" width="6" height="176" rx="3" fill="#FAFF69"/>
-<text x="52" y="568" fill="#EDEDED" font-size="14.5" font-weight="700">Observe</text>
-<text x="52" y="590" fill="#B7BCC2" font-size="11">modules 05, 06, 07</text>
-<rect x="216" y="560" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="324.0" y="582" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">backend spans</text>
-<text x="324.0" y="604" fill="#B7BCC2" font-size="12.5" text-anchor="middle">clickhouse.query + logs</text>
-<rect x="572" y="560" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="680.0" y="582" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">stateless OTel forwarder</text>
-<text x="680.0" y="604" fill="#B7BCC2" font-size="12.5" text-anchor="middle">local OTLP :4318</text>
-<rect x="928" y="560" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1036.0" y="582" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">otel db</text>
-<text x="1036.0" y="604" fill="#B7BCC2" font-size="12.5" text-anchor="middle">in your service</text>
-<rect x="1284" y="560" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1392.0" y="582" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">HyperDX UI</text>
-<text x="1392.0" y="604" fill="#B7BCC2" font-size="12.5" text-anchor="middle">search, traces, dashboards</text>
-<path d="M432,591 L566,591" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="479.6" y="569.0" width="38.8" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="499.0" y="582.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">OTLP</text>
-<path d="M788,591 L922,591" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="832.0" y="569.0" width="46.0" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="855.0" y="582.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">write</text>
-<path d="M1144,591 L1278,591" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="1191.6" y="569.0" width="38.8" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="1211.0" y="582.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">read</text>
-<rect x="572" y="642" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="680.0" y="664" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">coding agent</text>
-<text x="680.0" y="686" fill="#B7BCC2" font-size="12.5" text-anchor="middle">via ClickStack MCP</text>
-<path d="M680.0,642 L680.0,622" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<text x="922" y="676" fill="#B7BCC2" font-size="11.5">clickstack_search / save_dashboard / save_alert</text>
+<text x="30" y="44" fill="#EDEDED" font-size="22" font-weight="700">ClickHouse BUILD Workshop · A trip's path</text>
+<text x="30" y="70" fill="#B7BCC2" font-size="13.5">Read left to right: generate a trip, stream it into ClickHouse, then show it in the app.</text>
+<rect x="40" y="135" width="300" height="110" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="190.0" y="157" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Load generator</text>
+<text x="190.0" y="179" fill="#B7BCC2" font-size="14" text-anchor="middle">creates synthetic trips</text>
+<text x="190.0" y="197" fill="#B7BCC2" font-size="14" text-anchor="middle">on your laptop</text>
+<circle cx="60" cy="155" r="12" fill="#FAFF69"/>
+<text x="60" y="159" fill="#17171A" font-size="11" font-weight="700" text-anchor="middle">1</text>
+<rect x="450" y="135" width="300" height="110" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="600.0" y="157" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Managed Postgres</text>
+<text x="600.0" y="179" fill="#B7BCC2" font-size="14" text-anchor="middle">source table:</text>
+<text x="600.0" y="197" fill="#B7BCC2" font-size="14" text-anchor="middle">public.realtime_trips</text>
+<circle cx="470" cy="155" r="12" fill="#FAFF69"/>
+<text x="470" y="159" fill="#17171A" font-size="11" font-weight="700" text-anchor="middle">2</text>
+<rect x="860" y="135" width="300" height="110" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="1010.0" y="157" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">ClickPipes</text>
+<text x="1010.0" y="179" fill="#B7BCC2" font-size="14" text-anchor="middle">streams each change</text>
+<text x="1010.0" y="197" fill="#B7BCC2" font-size="14" text-anchor="middle">with Postgres CDC</text>
+<circle cx="880" cy="155" r="12" fill="#FAFF69"/>
+<text x="880" y="159" fill="#17171A" font-size="11" font-weight="700" text-anchor="middle">3</text>
+<rect x="860" y="345" width="300" height="110" rx="12" fill="#26262B" stroke="#FAFF69" stroke-width="2"/>
+<text x="1010.0" y="367" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">ClickHouse</text>
+<text x="1010.0" y="389" fill="#B7BCC2" font-size="14" text-anchor="middle">first landing table:</text>
+<text x="1010.0" y="407" fill="#B7BCC2" font-size="14" text-anchor="middle">default.realtime_trips</text>
+<circle cx="880" cy="365" r="12" fill="#FAFF69"/>
+<text x="880" y="369" fill="#17171A" font-size="11" font-weight="700" text-anchor="middle">4</text>
+<rect x="450" y="345" width="300" height="110" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="600.0" y="367" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Materialized view</text>
+<text x="600.0" y="389" fill="#B7BCC2" font-size="14" text-anchor="middle">moves new rows into</text>
+<text x="600.0" y="407" fill="#B7BCC2" font-size="14" text-anchor="middle">nyc_tlc_data.taxi_trips</text>
+<circle cx="470" cy="365" r="12" fill="#FAFF69"/>
+<text x="470" y="369" fill="#17171A" font-size="11" font-weight="700" text-anchor="middle">5</text>
+<rect x="40" y="345" width="300" height="110" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="190.0" y="367" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Frontend + FastAPI</text>
+<text x="190.0" y="389" fill="#B7BCC2" font-size="14" text-anchor="middle">reads taxi_trips for</text>
+<text x="190.0" y="407" fill="#B7BCC2" font-size="14" text-anchor="middle">the live dashboards</text>
+<circle cx="60" cy="365" r="12" fill="#FAFF69"/>
+<text x="60" y="369" fill="#17171A" font-size="11" font-weight="700" text-anchor="middle">6</text>
+<path d="M340,190 L443,190" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
+<rect x="368.4" y="153" width="53.2" height="20" rx="4" fill="#17171A"/>
+<text x="395" y="167" fill="#B7BCC2" font-size="12.5" text-anchor="middle">INSERT</text>
+<path d="M750,190 L853,190" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
+<rect x="789.2" y="153" width="31.6" height="20" rx="4" fill="#17171A"/>
+<text x="805" y="167" fill="#B7BCC2" font-size="12.5" text-anchor="middle">CDC</text>
+<path d="M1010,245 L1010,338" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
+<rect x="969.0" y="288" width="82.0" height="20" rx="4" fill="#17171A"/>
+<text x="1010" y="302" fill="#B7BCC2" font-size="12.5" text-anchor="middle">lands here</text>
+<path d="M860,400 L757,400" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
+<rect x="782.0" y="363" width="46.0" height="20" rx="4" fill="#17171A"/>
+<text x="805" y="377" fill="#B7BCC2" font-size="12.5" text-anchor="middle">feeds</text>
+<path d="M450,400 L347,400" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
+<rect x="372.0" y="363" width="46.0" height="20" rx="4" fill="#17171A"/>
+<text x="395" y="377" fill="#B7BCC2" font-size="12.5" text-anchor="middle">reads</text>
+<rect x="40" y="505" width="1120" height="75" rx="12" fill="#1C1C22" stroke="#3A3A45" stroke-width="1.3"/>
+<text x="65" y="535" fill="#FAFF69" font-size="13" font-weight="700">What the other workshop tools do</text>
+<text x="65" y="560" fill="#B7BCC2" font-size="12.5">ClickStack observes the app · ClickHouse Agents answers data questions · Langfuse traces the chat</text>
 </svg>

--- a/workshops/build_workshop/docs/diagrams/workshop-data-flow.svg
+++ b/workshops/build_workshop/docs/diagrams/workshop-data-flow.svg
@@ -2,41 +2,41 @@
 <rect x="0" y="0" width="1200" height="620" fill="#17171A"/>
 <defs><marker id="arrow" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L7,3 L0,6 Z" fill="#7E858E"/></marker></defs>
 <text x="30" y="44" fill="#EDEDED" font-size="22" font-weight="700">ClickHouse BUILD Workshop · A trip's path</text>
-<text x="30" y="70" fill="#B7BCC2" font-size="13.5">Read left to right: generate a trip, stream it into ClickHouse, then show it in the app.</text>
+<text x="30" y="70" fill="#B7BCC2" font-size="13.5">Follow steps 1–6: across the top, then back across the bottom.</text>
 <rect x="40" y="135" width="300" height="110" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="190.0" y="157" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Load generator</text>
-<text x="190.0" y="179" fill="#B7BCC2" font-size="14" text-anchor="middle">creates synthetic trips</text>
-<text x="190.0" y="197" fill="#B7BCC2" font-size="14" text-anchor="middle">on your laptop</text>
+<text x="190.0" y="157" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">Load generator</text>
+<text x="190.0" y="179" fill="#B7BCC2" font-size="14.5" text-anchor="middle">creates synthetic trips</text>
+<text x="190.0" y="197" fill="#B7BCC2" font-size="14.5" text-anchor="middle">on your laptop</text>
 <circle cx="60" cy="155" r="12" fill="#FAFF69"/>
 <text x="60" y="159" fill="#17171A" font-size="11" font-weight="700" text-anchor="middle">1</text>
 <rect x="450" y="135" width="300" height="110" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="600.0" y="157" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Managed Postgres</text>
-<text x="600.0" y="179" fill="#B7BCC2" font-size="14" text-anchor="middle">source table:</text>
-<text x="600.0" y="197" fill="#B7BCC2" font-size="14" text-anchor="middle">public.realtime_trips</text>
+<text x="600.0" y="157" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">Managed Postgres</text>
+<text x="600.0" y="179" fill="#B7BCC2" font-size="14.5" text-anchor="middle">source table:</text>
+<text x="600.0" y="197" fill="#B7BCC2" font-size="14.5" text-anchor="middle">public.realtime_trips</text>
 <circle cx="470" cy="155" r="12" fill="#FAFF69"/>
 <text x="470" y="159" fill="#17171A" font-size="11" font-weight="700" text-anchor="middle">2</text>
 <rect x="860" y="135" width="300" height="110" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1010.0" y="157" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">ClickPipes</text>
-<text x="1010.0" y="179" fill="#B7BCC2" font-size="14" text-anchor="middle">streams each change</text>
-<text x="1010.0" y="197" fill="#B7BCC2" font-size="14" text-anchor="middle">with Postgres CDC</text>
+<text x="1010.0" y="157" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">ClickPipes</text>
+<text x="1010.0" y="179" fill="#B7BCC2" font-size="14.5" text-anchor="middle">streams each change</text>
+<text x="1010.0" y="197" fill="#B7BCC2" font-size="14.5" text-anchor="middle">with Postgres CDC</text>
 <circle cx="880" cy="155" r="12" fill="#FAFF69"/>
 <text x="880" y="159" fill="#17171A" font-size="11" font-weight="700" text-anchor="middle">3</text>
 <rect x="860" y="345" width="300" height="110" rx="12" fill="#26262B" stroke="#FAFF69" stroke-width="2"/>
-<text x="1010.0" y="367" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">ClickHouse</text>
-<text x="1010.0" y="389" fill="#B7BCC2" font-size="14" text-anchor="middle">first landing table:</text>
-<text x="1010.0" y="407" fill="#B7BCC2" font-size="14" text-anchor="middle">default.realtime_trips</text>
+<text x="1010.0" y="367" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">ClickHouse</text>
+<text x="1010.0" y="389" fill="#B7BCC2" font-size="14.5" text-anchor="middle">first landing table:</text>
+<text x="1010.0" y="407" fill="#B7BCC2" font-size="14.5" text-anchor="middle">default.realtime_trips</text>
 <circle cx="880" cy="365" r="12" fill="#FAFF69"/>
 <text x="880" y="369" fill="#17171A" font-size="11" font-weight="700" text-anchor="middle">4</text>
 <rect x="450" y="345" width="300" height="110" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="600.0" y="367" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Materialized view</text>
-<text x="600.0" y="389" fill="#B7BCC2" font-size="14" text-anchor="middle">moves new rows into</text>
-<text x="600.0" y="407" fill="#B7BCC2" font-size="14" text-anchor="middle">nyc_tlc_data.taxi_trips</text>
+<text x="600.0" y="367" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">Materialized view</text>
+<text x="600.0" y="389" fill="#B7BCC2" font-size="14.5" text-anchor="middle">moves new rows into</text>
+<text x="600.0" y="407" fill="#B7BCC2" font-size="14.5" text-anchor="middle">nyc_tlc_data.taxi_trips</text>
 <circle cx="470" cy="365" r="12" fill="#FAFF69"/>
 <text x="470" y="369" fill="#17171A" font-size="11" font-weight="700" text-anchor="middle">5</text>
 <rect x="40" y="345" width="300" height="110" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="190.0" y="367" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Frontend + FastAPI</text>
-<text x="190.0" y="389" fill="#B7BCC2" font-size="14" text-anchor="middle">reads taxi_trips for</text>
-<text x="190.0" y="407" fill="#B7BCC2" font-size="14" text-anchor="middle">the live dashboards</text>
+<text x="190.0" y="367" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">Frontend + FastAPI</text>
+<text x="190.0" y="389" fill="#B7BCC2" font-size="14.5" text-anchor="middle">reads taxi_trips for</text>
+<text x="190.0" y="407" fill="#B7BCC2" font-size="14.5" text-anchor="middle">the live dashboards</text>
 <circle cx="60" cy="365" r="12" fill="#FAFF69"/>
 <text x="60" y="369" fill="#17171A" font-size="11" font-weight="700" text-anchor="middle">6</text>
 <path d="M340,190 L443,190" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>

--- a/workshops/build_workshop/docs/diagrams/workshop-module-flow.svg
+++ b/workshops/build_workshop/docs/diagrams/workshop-module-flow.svg
@@ -1,8 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1756" height="568" viewBox="0 0 1756 568" font-family="Inter, -apple-system, Segoe UI, Roboto, sans-serif">
-<rect x="0" y="0" width="1756" height="568" fill="#17171A"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="1756" height="402" viewBox="0 0 1756 402" font-family="Inter, -apple-system, Segoe UI, Roboto, sans-serif">
+<rect x="0" y="0" width="1756" height="402" fill="#17171A"/>
 <defs><marker id="arrow" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L7,3 L0,6 Z" fill="#7E858E"/></marker></defs>
 <text x="40" y="48" fill="#EDEDED" font-size="20" font-weight="700">ClickHouse BUILD Workshop · Module flow</text>
-<text x="40" y="70" fill="#B7BCC2" font-size="13">~2h30 core + optional 06b · only module 07 switches to a fault branch</text>
+<text x="40" y="70" fill="#B7BCC2" font-size="13">~2h30 hands-on · only module 07 switches to a fault branch</text>
 <rect x="40" y="92" width="300" height="96" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
 <rect x="40" y="92" width="5" height="96" rx="2.5" fill="#FAFF69"/>
 <text x="58" y="118" fill="#EDEDED" font-size="14.5" font-weight="700">00 Setup</text>
@@ -47,28 +47,22 @@
 <text x="1090" y="328" fill="#B7BCC2" font-size="12.5">builds dashboard + alert</text>
 <rect x="728" y="258" width="300" height="96" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
 <rect x="728" y="258" width="5" height="96" rx="2.5" fill="#FAFF69"/>
-<text x="746" y="284" fill="#EDEDED" font-size="14.5" font-weight="700">06b Hosted LibreChat</text>
-<text x="1014" y="284" fill="#FAFF69" font-size="12.5" font-weight="600" text-anchor="end">optional · 15 min</text>
-<text x="746" y="310" fill="#B7BCC2" font-size="12.5">remote ClickStack + GitHub MCP</text>
-<text x="746" y="328" fill="#B7BCC2" font-size="12.5">chat-native SRE workflow</text>
+<text x="746" y="284" fill="#EDEDED" font-size="14.5" font-weight="700">07 Test, fail, and fix</text>
+<text x="1014" y="284" fill="#FAFF69" font-size="12.5" font-weight="600" text-anchor="end">20 min</text>
+<text x="746" y="310" fill="#B7BCC2" font-size="12.5">inject a fault, diagnose</text>
+<text x="746" y="328" fill="#B7BCC2" font-size="12.5">with the AI SRE, fix it</text>
 <rect x="384" y="258" width="300" height="96" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
 <rect x="384" y="258" width="5" height="96" rx="2.5" fill="#FAFF69"/>
-<text x="402" y="284" fill="#EDEDED" font-size="14.5" font-weight="700">07 Test, fail, and fix</text>
-<text x="670" y="284" fill="#FAFF69" font-size="12.5" font-weight="600" text-anchor="end">20 min</text>
-<text x="402" y="310" fill="#B7BCC2" font-size="12.5">inject a fault, diagnose</text>
-<text x="402" y="328" fill="#B7BCC2" font-size="12.5">with the AI SRE, fix it</text>
+<text x="402" y="284" fill="#EDEDED" font-size="14.5" font-weight="700">08 Chat + Langfuse</text>
+<text x="670" y="284" fill="#FAFF69" font-size="12.5" font-weight="600" text-anchor="end">15 min</text>
+<text x="402" y="310" fill="#B7BCC2" font-size="12.5">in-app AI chat,</text>
+<text x="402" y="328" fill="#B7BCC2" font-size="12.5">every turn traced</text>
 <rect x="40" y="258" width="300" height="96" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
 <rect x="40" y="258" width="5" height="96" rx="2.5" fill="#FAFF69"/>
-<text x="58" y="284" fill="#EDEDED" font-size="14.5" font-weight="700">08 Chat + Langfuse</text>
-<text x="326" y="284" fill="#FAFF69" font-size="12.5" font-weight="600" text-anchor="end">15 min</text>
-<text x="58" y="310" fill="#B7BCC2" font-size="12.5">in-app AI chat,</text>
-<text x="58" y="328" fill="#B7BCC2" font-size="12.5">every turn traced</text>
-<rect x="40" y="424" width="300" height="96" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<rect x="40" y="424" width="5" height="96" rx="2.5" fill="#FAFF69"/>
-<text x="58" y="450" fill="#EDEDED" font-size="14.5" font-weight="700">09 Wrap-up</text>
-<text x="326" y="450" fill="#FAFF69" font-size="12.5" font-weight="600" text-anchor="end">10 min</text>
-<text x="58" y="476" fill="#B7BCC2" font-size="12.5">running prototype,</text>
-<text x="58" y="494" fill="#B7BCC2" font-size="12.5">take it home</text>
+<text x="58" y="284" fill="#EDEDED" font-size="14.5" font-weight="700">09 Wrap-up</text>
+<text x="326" y="284" fill="#FAFF69" font-size="12.5" font-weight="600" text-anchor="end">10 min</text>
+<text x="58" y="310" fill="#B7BCC2" font-size="12.5">running prototype,</text>
+<text x="58" y="328" fill="#B7BCC2" font-size="12.5">take it home</text>
 <path d="M340,140.0 L378,140.0" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
 <path d="M684,140.0 L722,140.0" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
 <path d="M1028,140.0 L1066,140.0" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
@@ -78,6 +72,5 @@
 <path d="M1072,306.0 L1034,306.0" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
 <path d="M728,306.0 L690,306.0" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
 <path d="M384,306.0 L346,306.0" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<path d="M190.0,354 L190.0,418" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
 <text x="40" y="228.0" fill="#B7BCC2" font-size="12" font-style="italic">After module 03: historical + live data both flowing into your Cloud service.</text>
 </svg>

--- a/workshops/build_workshop/playbook/content/docs/index.mdx
+++ b/workshops/build_workshop/playbook/content/docs/index.mdx
@@ -89,15 +89,15 @@ stateful data or product service is cloud-hosted from the start.
 ClickHouse Cloud is a single platform that spans the whole stack — from ingesting data at
 the bottom, to storing and analyzing it in ClickHouse, to observing it and layering AI on
 top. This workshop is a guided tour through exactly these pieces: you ingest with
-ClickPipes, analyze in ClickHouse, and observe with Managed ClickStack/HyperDX. Langfuse,
-OpenAI, and optional LibreChat are separate hosted services.
+ClickPipes, analyze in ClickHouse, and observe with Managed ClickStack/HyperDX. Langfuse
+and OpenAI are separate hosted services.
 
 ![The ClickHouse Cloud platform: layered stack from sources and ClickPipes ingestion, through ClickHouse and Postgres, up to HyperDX, Langfuse and agentic AI](/clickhouse-platform.svg)
 
 ### Architecture (target end state)
 
 Here is how those pieces come together: the app edge on your laptop; ClickHouse-managed
-state in your trial; and separate hosted OpenAI, Langfuse, and optional LibreChat services.
+state in your trial; and separate hosted OpenAI and Langfuse services.
 
 ![Workshop architecture: participant laptop, your ClickHouse Cloud trial (service, ClickPipes, managed Postgres), and third-party services](/workshop-architecture.svg)
 
@@ -111,11 +111,11 @@ via CDC, then read by the dashboards, chat, and agents, and observed through Cli
 The diagrams above are generated from `workshops/build_workshop/docs/diagrams/gen_diagrams.py`
 (edit the script and re-run it to regenerate the SVGs) — see the module flow below.
 
-![Module flow: ten core modules plus optional hosted LibreChat 06b](/workshop-module-flow.svg)
+![Module flow: ten core workshop modules](/workshop-module-flow.svg)
 
 ## Modules
 
-Ten core modules plus optional 06b, in order. The app is complete on `build-workshop-v1`, so every module except
+Ten core modules, in order. The app is complete on `build-workshop-v1`, so every module except
 07 needs no per-module checkout — you configure and connect services rather than change
 app code. The only branch switches are the fault branches in module 07.
 
@@ -128,8 +128,7 @@ app code. The only branch switches are the fault branches in module 07.
 | 04 | 10 min | [ClickHouse Agents](/docs/learner/04-clickhouse-agents) | [notes](/docs/instructor/04-clickhouse-agents) | `build-workshop-v1` | Conversational BI: create an agent over your taxi data and explore it in natural language |
 | 05 | 15 min | [ClickStack](/docs/learner/05-clickstack) | [notes](/docs/instructor/05-clickstack) | `build-workshop-v1` | Enable ClickStack and send app traces and logs to HyperDX |
 | 06 | 15 min | [AI SRE](/docs/learner/06-ai-sre) | [notes](/docs/instructor/06-ai-sre) | `build-workshop-v1` | Use the ClickStack MCP connection to build an SRE dashboard and alert |
-| 06b | Optional, 15 min | [Hosted LibreChat AI SRE](/docs/learner/06b-ai-sre-librechat) | [notes](/docs/instructor/06b-ai-sre-librechat) | `build-workshop-v1` | Use a hosted chat agent with remote ClickStack and GitHub MCP connections |
-| 07 | 20 min | [Test, fail, and fix](/docs/learner/07-break-and-fix) | [notes](/docs/instructor/07-break-and-fix) | `fault/*` | Continue from AI SRE or optional 06b, inject a fault, diagnose it, fix it, and prove recovery |
+| 07 | 20 min | [Test, fail, and fix](/docs/learner/07-break-and-fix) | [notes](/docs/instructor/07-break-and-fix) | `fault/*` | Continue from AI SRE, inject a fault, diagnose it, fix it, and prove recovery |
 | 08 | 15 min | [Chat and Langfuse](/docs/learner/08-chat-langfuse) | [notes](/docs/instructor/08-chat-langfuse) | `build-workshop-v1` | Use the in-app AI chat and follow its traces, generations, and costs in Langfuse |
 | 09 | 10 min | [Wrap-up](/docs/learner/09-wrap-up) | [notes](/docs/instructor/09-wrap-up) | `build-workshop-v1` | Review what you built, take it home, and extend it to your own data |
 

--- a/workshops/build_workshop/playbook/content/docs/index.mdx
+++ b/workshops/build_workshop/playbook/content/docs/index.mdx
@@ -96,17 +96,17 @@ and OpenAI are separate hosted services.
 
 ### Architecture (target end state)
 
-Here is how those pieces come together: the app edge on your laptop; ClickHouse-managed
-state in your trial; and separate hosted OpenAI and Langfuse services.
+First, group the pieces by where they run: the stateless app and tools on your laptop,
+stateful services in ClickHouse Cloud, and the separate hosted AI services.
 
-![Workshop architecture: participant laptop, your ClickHouse Cloud trial (service, ClickPipes, managed Postgres), and third-party services](/workshop-architecture.svg)
+![Workshop components grouped into participant laptop, ClickHouse Cloud, and external hosted services](/workshop-architecture.svg)
 
 ### How data flows
 
-The same picture, followed as data: seeded once from object storage, streamed continuously
-via CDC, then read by the dashboards, chat, and agents, and observed through ClickStack.
+Now follow one live trip from the local load generator through managed Postgres and
+ClickPipes, into `default.realtime_trips`, and finally into the application dashboards.
 
-![Data flow: four lanes — one-time seed, live CDC, read paths, and observability — all through your ClickHouse service](/workshop-data-flow.svg)
+![A live trip flows from the load generator to managed Postgres, through ClickPipes into default.realtime_trips, then through a materialized view to the app](/workshop-data-flow.svg)
 
 The diagrams above are generated from `workshops/build_workshop/docs/diagrams/gen_diagrams.py`
 (edit the script and re-run it to regenerate the SVGs) — see the module flow below.

--- a/workshops/build_workshop/playbook/content/docs/instructor/05-clickstack.mdx
+++ b/workshops/build_workshop/playbook/content/docs/instructor/05-clickstack.mdx
@@ -44,6 +44,6 @@ collector as early as this module allows and keep it running.
 ## Reset steps
 
 - Restart with both compose files:
-  `docker compose --env-file .env.workshop -f docker-compose.workshop.yml -f docker-compose.otel.yml up -d`.
+  `docker compose --env-file .env.workshop -f docker-compose.workshop.yml -f docker-compose.otel.yml up -d --build`.
 - In the Cloud console, open the service, choose **ClickStack**, and relaunch the hosted
   UI if the SSO session expired.

--- a/workshops/build_workshop/playbook/content/docs/instructor/05-clickstack.mdx
+++ b/workshops/build_workshop/playbook/content/docs/instructor/05-clickstack.mdx
@@ -15,6 +15,8 @@ collector as early as this module allows and keep it running.
 - Managed ClickStack stores telemetry in ClickHouse Cloud; HyperDX is the hosted UI.
   The local collector only forwards data. Show both an end-to-end request trace and a
   fresh `DEBUG ... ClickHouse query ok` record in the Log source.
+- Have learners start the collector in Step 1 before they launch Managed ClickStack in
+  Step 2. This gives telemetry time to arrive and makes the first hosted-UI view useful.
 - Show one end-to-end request trace on the projector.
 
 ## Common failures

--- a/workshops/build_workshop/playbook/content/docs/instructor/06-ai-sre.mdx
+++ b/workshops/build_workshop/playbook/content/docs/instructor/06-ai-sre.mdx
@@ -1,5 +1,5 @@
 ---
-title: 06a AI SRE
+title: 06 AI SRE
 description: Instructor notes for module 06 — timing, talk track, common failures, and reset steps.
 ---
 

--- a/workshops/build_workshop/playbook/content/docs/instructor/06b-ai-sre-librechat.mdx
+++ b/workshops/build_workshop/playbook/content/docs/instructor/06b-ai-sre-librechat.mdx
@@ -6,7 +6,8 @@ description: Archived instructor reference for the former optional hosted LibreC
 <Callout type="warn" title="Archived module">
   Module 06b is no longer part of the run of show. Do not provision LibreChat, learner
   accounts, or its MCP connections for the current workshop. Continue directly from
-  Module 06 to Module 07. The notes below remain only as a historical reference.
+  Module 06 to [Module 07](/docs/instructor/07-break-and-fix). The notes below remain
+  only as a historical reference.
 </Callout>
 
 Facilitator companion to

--- a/workshops/build_workshop/playbook/content/docs/instructor/06b-ai-sre-librechat.mdx
+++ b/workshops/build_workshop/playbook/content/docs/instructor/06b-ai-sre-librechat.mdx
@@ -1,17 +1,23 @@
 ---
-title: 06b AI SRE with hosted LibreChat
-description: Instructor prework and facilitation notes for the optional cloud-hosted LibreChat module.
+title: "Archived: 06b AI SRE with hosted LibreChat"
+description: Archived instructor reference for the former optional hosted LibreChat module.
 ---
+
+<Callout type="warn" title="Archived module">
+  Module 06b is no longer part of the run of show. Do not provision LibreChat, learner
+  accounts, or its MCP connections for the current workshop. Continue directly from
+  Module 06 to Module 07. The notes below remain only as a historical reference.
+</Callout>
 
 Facilitator companion to
 [06b AI SRE with hosted LibreChat](/docs/learner/06b-ai-sre-librechat).
 
-## Timing
+## Historical timing
 
-Optional, about 15 minutes. Run it immediately before Module 07. Skip it if the room is
-tight; Module 06a already covers the remote ClickStack MCP workflow.
+This module previously took about 15 minutes immediately before Module 07. Module 06
+already covers the remote ClickStack MCP workflow.
 
-## Required cloud prework
+## Historical cloud prework
 
 Learners must not deploy LibreChat or MongoDB locally.
 

--- a/workshops/build_workshop/playbook/content/docs/instructor/06b-ai-sre-librechat.mdx
+++ b/workshops/build_workshop/playbook/content/docs/instructor/06b-ai-sre-librechat.mdx
@@ -48,14 +48,14 @@ LibreChat documents remote MCP OAuth, per-user credentials, and agent sharing in
 
 ## Talk track
 
-- Module 06a is an agent in the editor; 06b is the same evidence chain in a hosted chat UI.
+- Module 06 is an agent in the editor; 06b was the same evidence chain in a hosted chat UI.
 - LibreChat is a client surface. ClickStack/HyperDX and the telemetry remain managed in
   ClickHouse Cloud; GitHub remains the source-of-truth service.
 - Each learner owns their ClickHouse OAuth session and GitHub PAT.
 
 ## Common failures
 
-- **Hosted URL is unavailable**: skip 06b and continue with Module 06a. Do not improvise a
+- **Hosted URL is unavailable**: skip this archived module and continue with Module 06. Do not improvise a
   local Docker deployment during the workshop.
 - **OAuth returns to the wrong host**: correct LibreChat's public `DOMAIN_SERVER` and
   `DOMAIN_CLIENT` to the HTTPS deployment URL, then reconnect.

--- a/workshops/build_workshop/playbook/content/docs/instructor/07-break-and-fix.mdx
+++ b/workshops/build_workshop/playbook/content/docs/instructor/07-break-and-fix.mdx
@@ -17,8 +17,6 @@ so the wrap-up is not squeezed.
 ## Talk track
 
 - This is the payoff: use everything built so far to run a real incident.
-- If the room completed 06b, fault 01 is already diagnosed — this module becomes
-  confirm-fix-verify, so keep the momentum and move quickly to the fix.
 - Describe the symptom, not the cause, and let the agents converge from telemetry.
 - Consider showing several attendees' diagnoses side by side on the projector.
 - The lab runs fault 01. If time permits an extra round, add fault 02 (and fault 03 only

--- a/workshops/build_workshop/playbook/content/docs/instructor/09-wrap-up.mdx
+++ b/workshops/build_workshop/playbook/content/docs/instructor/09-wrap-up.mdx
@@ -24,6 +24,6 @@ About 10 minutes. Reserve time for two or three volunteer demos on the projector
 
 ## Reset steps
 
-- Reset any shared state used for demos (managed Postgres fallback pool, hosted LibreChat,
-  projector channel).
+- Reset any shared state used for demos (managed Postgres fallback pool and projector
+  channel).
 - TODO: confirm the shared-state teardown checklist.

--- a/workshops/build_workshop/playbook/content/docs/instructor/index.mdx
+++ b/workshops/build_workshop/playbook/content/docs/instructor/index.mdx
@@ -31,8 +31,7 @@ the dry run and record the final numbers here.
 | 04 | ClickHouse Agents | 10 min | Beta tool; have a fallback question ready |
 | 05 | ClickStack | 15 min | Telemetry needs time to accumulate before module 07 |
 | 06 | AI SRE | 15 min | MCP OAuth is the fragile moment; pre-stage config |
-| 06b | Hosted LibreChat AI SRE | Optional, 15 min | Pre-provision HTTPS instance, model, accounts, and remote MCPs |
-| 07 | Break and fix | 20 min | Direct payoff from 06/06b; hard-stop management matters |
+| 07 | Break and fix | 20 min | Direct payoff from 06; hard-stop management matters |
 | 08 | Chat and Langfuse | 15 min | Keys already set in module 00; restart plus trace tour |
 | 09 | Wrap-up | 10 min | Volunteers demo; reset any shared state |
 
@@ -52,8 +51,6 @@ before doors open:
 
 - **Managed Postgres fallback pool** — cloud-hosted instances only for attendees whose
   org cannot create one. The primary path is one ClickHouse-managed Postgres per learner.
-- **Hosted LibreChat** — an HTTPS cloud deployment and learner accounts for optional
-  Module 06b. Do not run LibreChat or MongoDB on learner machines.
 - **Loaner ClickHouse Cloud services** — a small pool for attendees whose trial fails.
   TODO: pool size and distribution method.
 - **Runtime LLM key pool** — spend-capped fallback keys for the in-app chat (module 08).
@@ -77,7 +74,6 @@ should arrive then. TODO: confirm the clinic start time and staffing.
   <Card title="04 ClickHouse Agents" href="/docs/instructor/04-clickhouse-agents" />
   <Card title="05 ClickStack" href="/docs/instructor/05-clickstack" />
   <Card title="06 AI SRE" href="/docs/instructor/06-ai-sre" />
-  <Card title="06b Hosted LibreChat SRE" href="/docs/instructor/06b-ai-sre-librechat" />
   <Card title="07 Test, fail, and fix" href="/docs/instructor/07-break-and-fix" />
   <Card title="08 Chat and Langfuse" href="/docs/instructor/08-chat-langfuse" />
   <Card title="09 Wrap-up" href="/docs/instructor/09-wrap-up" />

--- a/workshops/build_workshop/playbook/content/docs/instructor/meta.json
+++ b/workshops/build_workshop/playbook/content/docs/instructor/meta.json
@@ -12,7 +12,6 @@
     "04-clickhouse-agents",
     "05-clickstack",
     "06-ai-sre",
-    "06b-ai-sre-librechat",
     "07-break-and-fix",
     "08-chat-langfuse",
     "09-wrap-up"

--- a/workshops/build_workshop/playbook/content/docs/learner/00-setup.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/00-setup.mdx
@@ -17,7 +17,7 @@ In about **25 minutes** you will have:
 - Langfuse and OpenAI keys; and
 - the app healthy at [localhost:8080](http://localhost:8080).
 
-ClickHouse, Postgres, ClickPipes, ClickStack/HyperDX, Langfuse, LibreChat, and MCP
+ClickHouse, Postgres, ClickPipes, ClickStack/HyperDX, Langfuse, and MCP
 endpoints are cloud-hosted. Only the workshop app, CLI/client tools, coding agent,
 load generator, and stateless telemetry collector run on your machine.
 

--- a/workshops/build_workshop/playbook/content/docs/learner/05-clickstack.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/05-clickstack.mdx
@@ -43,15 +43,6 @@ telemetry and is not a local ClickStack or HyperDX deployment.
 
 ### `.env.workshop` and `docker-compose.otel.yml`
 
-Append the observability variables to your single `.env.workshop`, then bring the stack
-up with the overlay. The overlay sets `OTEL_ENABLED=true` on the back end for you and
-adds the `otel-collector` service (`clickhouse/clickstack-otel-collector`):
-
-```bash
-docker compose --env-file .env.workshop \
-  -f docker-compose.workshop.yml -f docker-compose.otel.yml up -d
-```
-
 These live in the ClickStack observability section of `.env.workshop.example`; fill them
 in your `.env.workshop`:
 
@@ -60,6 +51,23 @@ OTLP_AUTH_TOKEN=change-me-workshop-token   # shared secret securing OTLP ingest
 CLICKSTACK_DATABASE=otel                   # ClickStack's own otel_* tables
 OTEL_SERVICE_NAME=nyc-taxi-backend         # the service name shown in HyperDX
 LOG_LEVEL=DEBUG                            # show successful queries in Log source
+```
+
+Source the updated file so later commands can use the same values:
+
+```bash
+set -a
+source .env.workshop
+set +a
+```
+
+Now bring the stack up with the overlay. The overlay sets `OTEL_ENABLED=true` on the
+back end, adds the `otel-collector` service (`clickhouse/clickstack-otel-collector`),
+and rebuilds the front end with the browser telemetry settings:
+
+```bash
+docker compose --env-file .env.workshop \
+  -f docker-compose.workshop.yml -f docker-compose.otel.yml up -d --build
 ```
 
 The collector reuses `CLICKHOUSE_HOST` / `CLICKHOUSE_PORT` / `CLICKHOUSE_USER` /

--- a/workshops/build_workshop/playbook/content/docs/learner/05-clickstack.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/05-clickstack.mdx
@@ -1,6 +1,6 @@
 ---
 title: 05 ClickStack
-description: Enable Managed ClickStack, forward telemetry with a local stateless collector, and inspect it in cloud-hosted HyperDX.
+description: Forward telemetry with a local stateless collector, enable Managed ClickStack, and inspect it in cloud-hosted HyperDX.
 ---
 
 ## Starting point
@@ -23,35 +23,7 @@ produces telemetry you can query.
 App traces and backend query logs flowing into ClickStack, with at least one end-to-end
 request trace and a visible stream of successful query records.
 
-## Step 1 — Enable Managed ClickStack on your service
-
-The workshop uses **Managed ClickStack (HyperDX)** inside your own ClickHouse Cloud
-service: the collector writes `otel_*` tables to your service and the HyperDX UI renders
-them there. Enable it in the console:
-
-Console - your service -> **ClickStack** -> **Start Ingestion** -> skip the collector
-step (the app ships its own collector in Step 2) -> **Launch ClickStack**
-
-That single-signs you on into HyperDX. (The UI is empty at this point — telemetry starts
-flowing once the collector overlay is running in Step 2.)
-
-<Callout title="Managed ClickStack: what diverges from the classic setup">
-  - The back end uses vanilla OpenTelemetry, not the convenience
-    `hyperdx-opentelemetry` package the ClickStack docs suggest. That package hard-pins
-    `opentelemetry-api==1.30.0`, which conflicts with the Langfuse v4 SDK the chat
-    feature uses (needs `opentelemetry-api>=1.33.1`) — the two cannot share one
-    environment. The ClickStack collector ingests standard OTLP, so the vanilla distro
-    behaves identically; the workshop just sets the exporter env vars itself.
-  - ClickStack's telemetry lives in a separate database on your service
-    (`CLICKSTACK_DATABASE=otel`), distinct from the app's data database
-    (`CLICKHOUSE_DATABASE=nyc_tlc_data`).
-  - Traces and backend Python logs flow over OTLP from the auto-instrumented back end.
-    The optional `--profile container-logs` collector is only for non-instrumented
-    services such as the trip writer; its Linux Docker log path may not be available on
-    Docker Desktop.
-</Callout>
-
-## Step 2 — Run the OpenTelemetry collector overlay
+## Step 1 — Run the OpenTelemetry collector overlay
 
 HyperDX, storage, and query compute stay managed in ClickHouse Cloud. The only local
 component here is a stateless OpenTelemetry collector beside the local app; it forwards
@@ -94,6 +66,34 @@ The collector reuses `CLICKHOUSE_HOST` / `CLICKHOUSE_PORT` / `CLICKHOUSE_USER` /
 `CLICKHOUSE_PASSWORD` from `.env.workshop`; the back end exports OTLP to
 `http://otel-collector:4318` (HTTP/protobuf). To also scrape raw container stdout on a
 Linux host, add `--profile container-logs`.
+
+## Step 2 — Enable Managed ClickStack on your service
+
+The workshop uses **Managed ClickStack (HyperDX)** inside your own ClickHouse Cloud
+service: the collector writes `otel_*` tables to your service and the HyperDX UI renders
+them there. Enable it in the console:
+
+Console - your service -> **ClickStack** -> **Start Ingestion** -> skip the collector
+step (the app collector is already running from Step 1) -> **Launch ClickStack**
+
+That single-signs you on into HyperDX. Telemetry has already started flowing, so the
+hosted UI can populate as soon as it opens.
+
+<Callout title="Managed ClickStack: what diverges from the classic setup">
+  - The back end uses vanilla OpenTelemetry, not the convenience
+    `hyperdx-opentelemetry` package the ClickStack docs suggest. That package hard-pins
+    `opentelemetry-api==1.30.0`, which conflicts with the Langfuse v4 SDK the chat
+    feature uses (needs `opentelemetry-api>=1.33.1`) — the two cannot share one
+    environment. The ClickStack collector ingests standard OTLP, so the vanilla distro
+    behaves identically; the workshop just sets the exporter env vars itself.
+  - ClickStack's telemetry lives in a separate database on your service
+    (`CLICKSTACK_DATABASE=otel`), distinct from the app's data database
+    (`CLICKHOUSE_DATABASE=nyc_tlc_data`).
+  - Traces and backend Python logs flow over OTLP from the auto-instrumented back end.
+    The optional `--profile container-logs` collector is only for non-instrumented
+    services such as the trip writer; its Linux Docker log path may not be available on
+    Docker Desktop.
+</Callout>
 
 ## Step 3 — Generate and find traffic in ClickStack
 

--- a/workshops/build_workshop/playbook/content/docs/learner/06-ai-sre.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/06-ai-sre.mdx
@@ -125,8 +125,6 @@ artifacts from it. That is exactly what you will lean on when something breaks.
 
 ## End state
 
-An AI-built SRE dashboard and alert are in place. Continue to optional
-[06b AI SRE with LibreChat](/docs/learner/06b-ai-sre-librechat) if you want a chat-native
-agent that reads both telemetry and source, then use that agent in
-[07 Test, fail, and fix](/docs/learner/07-break-and-fix). If you are skipping 06b, go straight
-to module 07 with the editor agent you configured here.
+An AI-built SRE dashboard and alert are in place. Continue to
+[07 Test, fail, and fix](/docs/learner/07-break-and-fix) with the editor agent you
+configured here.

--- a/workshops/build_workshop/playbook/content/docs/learner/06-ai-sre.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/06-ai-sre.mdx
@@ -1,5 +1,5 @@
 ---
-title: 06a AI SRE
+title: 06 AI SRE
 description: Connect your coding agent to the ClickStack MCP and have it build an SRE dashboard and an alert over your telemetry.
 ---
 

--- a/workshops/build_workshop/playbook/content/docs/learner/06b-ai-sre-librechat.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/06b-ai-sre-librechat.mdx
@@ -1,11 +1,19 @@
 ---
-title: 06b AI SRE with hosted LibreChat
-description: Optional — use a cloud-hosted LibreChat SRE agent with remote ClickStack and GitHub MCP connections.
+title: "Archived: 06b AI SRE with hosted LibreChat"
+description: Archived reference for the former optional hosted LibreChat module.
 ---
 
-## Starting point
+<Callout type="warn" title="Archived module">
+  Module 06b is no longer part of the workshop. Do not provision LibreChat for the
+  current learner path. Continue directly from [06 AI SRE](/docs/learner/06-ai-sre) to
+  [07 Test, fail, and fix](/docs/learner/07-break-and-fix). The material below remains
+  available only as a historical reference.
+</Callout>
 
-Optional module. You are on `build-workshop-v1`; budget about **15 minutes**.
+## Historical starting point
+
+When this module was active, learners stayed on `build-workshop-v1` and budgeted about
+**15 minutes**.
 
 Prerequisites: Module 05 is complete, your instructor has provided an HTTPS LibreChat
 URL and account, and you have a fine-grained GitHub token with read-only access to
@@ -93,4 +101,4 @@ The agent should connect the `nyc-taxi-frontend` error to
 - The agent has connected remote `clickstack` and `github` MCP tools.
 - Its diagnosis cites both telemetry and a source file on the selected fault branch.
 
-Continue to [07 Test, fail, and fix](/docs/learner/07-break-and-fix).
+The active workshop continues at [07 Test, fail, and fix](/docs/learner/07-break-and-fix).

--- a/workshops/build_workshop/playbook/content/docs/learner/06b-ai-sre-librechat.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/06b-ai-sre-librechat.mdx
@@ -29,7 +29,7 @@ starting this module.
 
 ## Why
 
-Module 06a put the agent in your editor. Here a chat-native SRE agent investigates two
+Module 06 put the agent in your editor. Here a chat-native SRE agent investigates two
 remote planes at once: ClickStack telemetry and the public workshop source on GitHub.
 
 ## Step 1 — Sign in to hosted LibreChat

--- a/workshops/build_workshop/playbook/content/docs/learner/07-break-and-fix.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/07-break-and-fix.mdx
@@ -6,8 +6,7 @@ description: Inject a known fault, diagnose it through ClickStack, apply a fix, 
 ## Outcome
 
 In about **20 minutes**, you will run one incident from failure to verified recovery. This
-continues directly from Module 06a or optional 06b and uses the ClickStack MCP configured
-in Module 00.
+continues directly from Module 06 and uses the ClickStack MCP configured in Module 00.
 
 ## Step 1 — Choose one fault
 
@@ -39,9 +38,6 @@ docker compose --env-file .env.workshop \
 
 Open a fresh browser session at [localhost:8080](http://localhost:8080). **The empty map is
 expected now**; a failure elsewhere is not part of this scenario.
-
-If Module 06b already injected Fault 01, skip the branch switch and rebuild only the
-frontend.
 
 ## Step 3 — Diagnose from evidence
 

--- a/workshops/build_workshop/playbook/content/docs/learner/index.mdx
+++ b/workshops/build_workshop/playbook/content/docs/learner/index.mdx
@@ -21,8 +21,7 @@ on WSL 2, so all shared command blocks are identical after setup.
 4. [ClickHouse Agents](/docs/learner/04-clickhouse-agents) - ask your data questions in plain language.
 5. [ClickStack](/docs/learner/05-clickstack) - see the app's own traces and logs in HyperDX.
 6. [AI SRE](/docs/learner/06-ai-sre) - have your agent build an SRE dashboard and alert over that telemetry.
-6b. [Hosted LibreChat AI SRE](/docs/learner/06b-ai-sre-librechat) - optional hosted chat workflow over ClickStack and GitHub MCP.
-7. [Break and fix](/docs/learner/07-break-and-fix) - continue from AI SRE or optional 06b, inject a fault, diagnose it, and fix it.
+7. [Break and fix](/docs/learner/07-break-and-fix) - continue from AI SRE, inject a fault, diagnose it, and fix it.
 8. [Chat and Langfuse](/docs/learner/08-chat-langfuse) - wire an in-app AI chat and trace every turn.
 9. [Wrap-up](/docs/learner/09-wrap-up) - recap, take it home, extend it to your own data.
 
@@ -44,8 +43,7 @@ About **2h30 hands-on** - and your dashboard is live on real data within the fir
 ## Cost
 
 ClickHouse Cloud trial credits cover the ClickHouse-managed services. Budget about
-**$5 of OpenAI credit** for Module 08. Optional self-paced Module 06b may also incur a
-small Railway hosting charge; instructor-led sessions use the provided hosted instance.
+**$5 of OpenAI credit** for Module 08.
 
 ## Everything is copy-paste
 

--- a/workshops/build_workshop/playbook/content/docs/learner/meta.json
+++ b/workshops/build_workshop/playbook/content/docs/learner/meta.json
@@ -13,7 +13,6 @@
     "04-clickhouse-agents",
     "05-clickstack",
     "06-ai-sre",
-    "06b-ai-sre-librechat",
     "07-break-and-fix",
     "08-chat-langfuse",
     "09-wrap-up",

--- a/workshops/build_workshop/playbook/public/workshop-architecture.svg
+++ b/workshops/build_workshop/playbook/public/workshop-architecture.svg
@@ -1,60 +1,54 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1500" height="650" viewBox="0 0 1500 650" font-family="Inter, -apple-system, Segoe UI, Roboto, sans-serif">
-<rect x="0" y="0" width="1500" height="650" fill="#17171A"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="650" viewBox="0 0 1200 650" font-family="Inter, -apple-system, Segoe UI, Roboto, sans-serif">
+<rect x="0" y="0" width="1200" height="650" fill="#17171A"/>
 <defs><marker id="arrow" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L7,3 L0,6 Z" fill="#7E858E"/></marker></defs>
 <text x="30" y="44" fill="#EDEDED" font-size="22" font-weight="700">ClickHouse BUILD Workshop · Where each component runs</text>
-<text x="30" y="70" fill="#B7BCC2" font-size="13.5">Group components by location first. Follow the next diagram for the trip data path.</text>
-<rect x="30" y="110" width="430" height="480" rx="16" fill="#1B2531" stroke="#3E5A78" stroke-width="1.6" opacity="0.96"/>
-<text x="48" y="136" fill="#3E5A78" font-size="15" font-weight="700" letter-spacing="0.5">PARTICIPANT LAPTOP  ·  the NYC-taxi app runs here</text>
-<rect x="510" y="110" width="620" height="480" rx="16" fill="#211F14" stroke="#FAFF69" stroke-width="1.6" opacity="0.96"/>
-<text x="528" y="136" fill="#FAFF69" font-size="15" font-weight="700" letter-spacing="0.5">CLICKHOUSE CLOUD  ·  your trial org (you create all of this)</text>
-<rect x="1180" y="110" width="290" height="480" rx="16" fill="#1E1E22" stroke="#54545C" stroke-width="1.6" opacity="0.96"/>
-<text x="1198" y="136" fill="#54545C" font-size="15" font-weight="700" letter-spacing="0.5">THIRD-PARTY</text>
-<rect x="60" y="165" width="370" height="78" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="245.0" y="187" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Frontend + FastAPI</text>
-<text x="245.0" y="209" fill="#B7BCC2" font-size="14" text-anchor="middle">dashboards, chat, and API</text>
-<text x="245.0" y="227" fill="#B7BCC2" font-size="14" text-anchor="middle">runs with Docker Compose</text>
-<rect x="60" y="270" width="370" height="68" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="245.0" y="292" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Load generator</text>
-<text x="245.0" y="314" fill="#B7BCC2" font-size="14" text-anchor="middle">creates synthetic trip rows</text>
-<rect x="60" y="365" width="370" height="68" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="245.0" y="387" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">OpenTelemetry forwarder</text>
-<text x="245.0" y="409" fill="#B7BCC2" font-size="14" text-anchor="middle">sends app telemetry to ClickStack</text>
-<rect x="60" y="460" width="370" height="78" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="245.0" y="482" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Coding agent + clickhousectl</text>
-<text x="245.0" y="504" fill="#B7BCC2" font-size="14" text-anchor="middle">workshop commands, MCP,</text>
-<text x="245.0" y="522" fill="#B7BCC2" font-size="14" text-anchor="middle">and ClickHouse skills</text>
-<rect x="540" y="165" width="560" height="88" rx="12" fill="#26262B" stroke="#FAFF69" stroke-width="2"/>
-<text x="820.0" y="187" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">ClickHouse service</text>
-<text x="820.0" y="209" fill="#B7BCC2" font-size="14" text-anchor="middle">default.realtime_trips lands here</text>
-<text x="820.0" y="227" fill="#B7BCC2" font-size="14" text-anchor="middle">nyc_tlc_data.taxi_trips powers the app</text>
-<rect x="540" y="285" width="265" height="78" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="672.5" y="307" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Managed Postgres</text>
-<text x="672.5" y="329" fill="#B7BCC2" font-size="14" text-anchor="middle">public.realtime_trips</text>
-<rect x="835" y="285" width="265" height="78" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="967.5" y="307" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">ClickPipes</text>
-<text x="967.5" y="329" fill="#B7BCC2" font-size="14" text-anchor="middle">streams Postgres changes</text>
-<rect x="540" y="395" width="265" height="88" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="672.5" y="417" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Managed ClickStack</text>
-<text x="672.5" y="439" fill="#B7BCC2" font-size="14" text-anchor="middle">HyperDX traces, logs,</text>
-<text x="672.5" y="457" fill="#B7BCC2" font-size="14" text-anchor="middle">dashboards, and alerts</text>
-<rect x="835" y="395" width="265" height="88" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="967.5" y="417" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Agents + remote MCP</text>
-<text x="967.5" y="439" fill="#B7BCC2" font-size="14" text-anchor="middle">ask questions and let</text>
-<text x="967.5" y="457" fill="#B7BCC2" font-size="14" text-anchor="middle">the coding agent use tools</text>
-<rect x="1210" y="175" width="230" height="82" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1325.0" y="197" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">OpenAI API</text>
-<text x="1325.0" y="219" fill="#B7BCC2" font-size="14" text-anchor="middle">chat completions</text>
-<rect x="1210" y="290" width="230" height="82" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1325.0" y="312" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Langfuse Cloud</text>
-<text x="1325.0" y="334" fill="#B7BCC2" font-size="14" text-anchor="middle">chat traces and cost</text>
-<rect x="1210" y="405" width="230" height="92" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1325.0" y="427" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">NYC TLC dataset</text>
-<text x="1325.0" y="449" fill="#B7BCC2" font-size="14" text-anchor="middle">one-time historical</text>
-<text x="1325.0" y="467" fill="#B7BCC2" font-size="14" text-anchor="middle">seed source</text>
-<path d="M460,565 L510,565" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="465.6" y="534" width="38.8" height="20" rx="4" fill="#17171A"/>
-<text x="485" y="548" fill="#B7BCC2" font-size="12.5" text-anchor="middle">uses</text>
-<path d="M1130,565 L1180,565" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="1132.0" y="534" width="46.0" height="20" rx="4" fill="#17171A"/>
-<text x="1155" y="548" fill="#B7BCC2" font-size="12.5" text-anchor="middle">calls</text>
+<text x="30" y="70" fill="#B7BCC2" font-size="13.5">Grouped by location; no data direction is implied. Follow the next diagram for the trip path.</text>
+<rect x="30" y="110" width="330" height="480" rx="16" fill="#1B2531" stroke="#3E5A78" stroke-width="1.6" opacity="0.96"/>
+<text x="48" y="136" fill="#B7BCC2" font-size="16" font-weight="700" letter-spacing="0.5">PARTICIPANT LAPTOP · local app + tools</text>
+<rect x="400" y="110" width="500" height="480" rx="16" fill="#211F14" stroke="#FAFF69" stroke-width="1.6" opacity="0.96"/>
+<text x="418" y="136" fill="#FAFF69" font-size="16" font-weight="700" letter-spacing="0.5">CLICKHOUSE CLOUD · your trial org</text>
+<rect x="940" y="110" width="230" height="480" rx="16" fill="#1E1E22" stroke="#54545C" stroke-width="1.6" opacity="0.96"/>
+<text x="958" y="136" fill="#B7BCC2" font-size="16" font-weight="700" letter-spacing="0.5">EXTERNAL SERVICES</text>
+<rect x="50" y="165" width="290" height="78" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="195.0" y="187" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">Frontend + FastAPI</text>
+<text x="195.0" y="209" fill="#B7BCC2" font-size="14.5" text-anchor="middle">dashboards, chat, and API</text>
+<text x="195.0" y="227" fill="#B7BCC2" font-size="14.5" text-anchor="middle">runs with Docker Compose</text>
+<rect x="50" y="270" width="290" height="68" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="195.0" y="292" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">Load generator</text>
+<text x="195.0" y="314" fill="#B7BCC2" font-size="14.5" text-anchor="middle">creates synthetic trip rows</text>
+<rect x="50" y="365" width="290" height="68" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="195.0" y="387" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">OTel forwarder</text>
+<text x="195.0" y="409" fill="#B7BCC2" font-size="14.5" text-anchor="middle">sends telemetry to ClickStack</text>
+<rect x="50" y="460" width="290" height="78" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="195.0" y="482" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">Coding agent + CLI</text>
+<text x="195.0" y="504" fill="#B7BCC2" font-size="14.5" text-anchor="middle">workshop commands, MCP,</text>
+<text x="195.0" y="522" fill="#B7BCC2" font-size="14.5" text-anchor="middle">and ClickHouse skills</text>
+<rect x="425" y="165" width="450" height="88" rx="12" fill="#26262B" stroke="#FAFF69" stroke-width="2"/>
+<text x="650.0" y="187" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">ClickHouse service</text>
+<text x="650.0" y="209" fill="#B7BCC2" font-size="14.5" text-anchor="middle">default.realtime_trips lands here</text>
+<text x="650.0" y="227" fill="#B7BCC2" font-size="14.5" text-anchor="middle">nyc_tlc_data.taxi_trips powers the app</text>
+<rect x="425" y="285" width="215" height="78" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="532.5" y="307" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">Managed Postgres</text>
+<text x="532.5" y="329" fill="#B7BCC2" font-size="14.5" text-anchor="middle">public.realtime_trips</text>
+<rect x="660" y="285" width="215" height="78" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="767.5" y="307" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">ClickPipes</text>
+<text x="767.5" y="329" fill="#B7BCC2" font-size="14.5" text-anchor="middle">streams Postgres changes</text>
+<rect x="425" y="395" width="215" height="88" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="532.5" y="417" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">Managed ClickStack</text>
+<text x="532.5" y="439" fill="#B7BCC2" font-size="14.5" text-anchor="middle">HyperDX traces, logs,</text>
+<text x="532.5" y="457" fill="#B7BCC2" font-size="14.5" text-anchor="middle">dashboards, and alerts</text>
+<rect x="660" y="395" width="215" height="88" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="767.5" y="417" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">Agents + MCP</text>
+<text x="767.5" y="439" fill="#B7BCC2" font-size="14.5" text-anchor="middle">data questions and</text>
+<text x="767.5" y="457" fill="#B7BCC2" font-size="14.5" text-anchor="middle">coding-agent tools</text>
+<rect x="960" y="175" width="190" height="82" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="1055.0" y="197" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">OpenAI API</text>
+<text x="1055.0" y="219" fill="#B7BCC2" font-size="14.5" text-anchor="middle">chat completions</text>
+<rect x="960" y="290" width="190" height="82" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="1055.0" y="312" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">Langfuse Cloud</text>
+<text x="1055.0" y="334" fill="#B7BCC2" font-size="14.5" text-anchor="middle">chat traces and cost</text>
+<rect x="960" y="405" width="190" height="92" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="1055.0" y="427" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">NYC TLC dataset</text>
+<text x="1055.0" y="449" fill="#B7BCC2" font-size="14.5" text-anchor="middle">one-time historical</text>
+<text x="1055.0" y="467" fill="#B7BCC2" font-size="14.5" text-anchor="middle">seed source</text>
 </svg>

--- a/workshops/build_workshop/playbook/public/workshop-architecture.svg
+++ b/workshops/build_workshop/playbook/public/workshop-architecture.svg
@@ -1,104 +1,60 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1700" height="1000" viewBox="0 0 1700 1000" font-family="Inter, -apple-system, Segoe UI, Roboto, sans-serif">
-<rect x="0" y="0" width="1700" height="1000" fill="#17171A"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="1500" height="650" viewBox="0 0 1500 650" font-family="Inter, -apple-system, Segoe UI, Roboto, sans-serif">
+<rect x="0" y="0" width="1500" height="650" fill="#17171A"/>
 <defs><marker id="arrow" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L7,3 L0,6 Z" fill="#7E858E"/></marker></defs>
-<text x="30" y="44" fill="#EDEDED" font-size="22" font-weight="700">ClickHouse BUILD Workshop · Architecture (target end state)</text>
-<text x="30" y="70" fill="#B7BCC2" font-size="13.5">App-side components run locally; stateful data services run in ClickHouse Cloud. Dashed lines are control/OAuth; solid lines are data.</text>
-<rect x="30" y="135" width="515" height="700" rx="16" fill="#1B2531" stroke="#3E5A78" stroke-width="1.6" opacity="0.96"/>
-<text x="48" y="161" fill="#3E5A78" font-size="13" font-weight="700" letter-spacing="0.5">PARTICIPANT LAPTOP  ·  the NYC-taxi app runs here</text>
-<rect x="590" y="135" width="650" height="760" rx="16" fill="#211F14" stroke="#FAFF69" stroke-width="1.6" opacity="0.96"/>
-<text x="608" y="161" fill="#FAFF69" font-size="13" font-weight="700" letter-spacing="0.5">CLICKHOUSE CLOUD  ·  your trial org (you create all of this)</text>
-<rect x="1290" y="135" width="380" height="560" rx="16" fill="#1E1E22" stroke="#54545C" stroke-width="1.6" opacity="0.96"/>
-<text x="1308" y="161" fill="#54545C" font-size="13" font-weight="700" letter-spacing="0.5">THIRD-PARTY</text>
-<rect x="60" y="190" width="455" height="62" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="287.5" y="212" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">frontend</text>
-<text x="287.5" y="234" fill="#B7BCC2" font-size="12.5" text-anchor="middle">React SPA · nginx :8080</text>
-<text x="287.5" y="252" fill="#B7BCC2" font-size="12.5" text-anchor="middle">Ops + Historical dashboards, chat</text>
-<rect x="60" y="300" width="455" height="62" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="287.5" y="322" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">backend</text>
-<text x="287.5" y="344" fill="#B7BCC2" font-size="12.5" text-anchor="middle">FastAPI :8000</text>
-<text x="287.5" y="362" fill="#B7BCC2" font-size="12.5" text-anchor="middle">analytics API + /api/chat (NL-to-SQL)</text>
-<rect x="60" y="410" width="455" height="56" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="287.5" y="432" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">otel-collector</text>
-<text x="287.5" y="454" fill="#B7BCC2" font-size="12.5" text-anchor="middle">ClickStack overlay (module 05)</text>
-<rect x="60" y="520" width="455" height="62" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="287.5" y="542" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">pg-trip-writer</text>
-<text x="287.5" y="564" fill="#B7BCC2" font-size="12.5" text-anchor="middle">synthetic trips; creates the CDC</text>
-<text x="287.5" y="582" fill="#B7BCC2" font-size="12.5" text-anchor="middle">table + publication on first run</text>
-<rect x="60" y="660" width="455" height="62" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="287.5" y="682" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">coding agent + clickhousectl</text>
-<text x="287.5" y="704" fill="#B7BCC2" font-size="12.5" text-anchor="middle">Claude Code / Cursor / Codex</text>
-<text x="287.5" y="722" fill="#B7BCC2" font-size="12.5" text-anchor="middle">+ ClickHouse skills + docs llms.txt</text>
-<rect x="620" y="185" width="590" height="96" rx="12" fill="#26262B" stroke="#FAFF69" stroke-width="2"/>
-<text x="915.0" y="207" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">ClickHouse service  :8443 TLS</text>
-<text x="915.0" y="229" fill="#B7BCC2" font-size="12.5" text-anchor="middle">nyc_tlc_data (taxi_trips, taxi_zones,</text>
-<text x="915.0" y="247" fill="#B7BCC2" font-size="12.5" text-anchor="middle">views, CDC MV)   +   otel db (logs, traces)</text>
-<rect x="620" y="330" width="280" height="88" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="760.0" y="352" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">ClickPipes</text>
-<text x="760.0" y="374" fill="#B7BCC2" font-size="12.5" text-anchor="middle">Postgres CDC pipe</text>
-<text x="760.0" y="392" fill="#B7BCC2" font-size="12.5" text-anchor="middle">snapshot + stream (~60s)</text>
-<rect x="930" y="330" width="280" height="88" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1070.0" y="352" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">Managed ClickStack / HyperDX</text>
-<text x="1070.0" y="374" fill="#B7BCC2" font-size="12.5" text-anchor="middle">traces + logs UI</text>
-<text x="1070.0" y="392" fill="#B7BCC2" font-size="12.5" text-anchor="middle">module 05</text>
-<rect x="620" y="500" width="590" height="82" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="915.0" y="522" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">Postgres managed by ClickHouse  :5432 TLS</text>
-<text x="915.0" y="544" fill="#B7BCC2" font-size="12.5" text-anchor="middle">you create it with clickhousectl (module 03) · public.realtime_trips + pub_taxi</text>
-<rect x="620" y="628" width="280" height="74" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="760.0" y="650" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">Remote MCP</text>
-<text x="760.0" y="672" fill="#B7BCC2" font-size="12.5" text-anchor="middle">/mcp + /clickstack (OAuth)</text>
-<rect x="930" y="628" width="280" height="74" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1070.0" y="650" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">ClickHouse Agents</text>
-<text x="1070.0" y="672" fill="#B7BCC2" font-size="12.5" text-anchor="middle">ai.clickhouse.cloud (module 04)</text>
-<rect x="620" y="748" width="590" height="60" rx="12" fill="#1C1B14" stroke="#4C4C55" stroke-width="1.3" stroke-dasharray="5 4"/>
-<text x="915.0" y="770" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">Instructor cloud fallback only</text>
-<text x="915.0" y="792" fill="#B7BCC2" font-size="12.5" text-anchor="middle">managed Postgres pool when a trial org cannot create one</text>
-<rect x="1315" y="195" width="330" height="74" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1480.0" y="217" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">Langfuse Cloud</text>
-<text x="1480.0" y="239" fill="#B7BCC2" font-size="12.5" text-anchor="middle">chat traces, sessions, cost</text>
-<rect x="1315" y="300" width="330" height="74" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1480.0" y="322" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">OpenAI API</text>
-<text x="1480.0" y="344" fill="#B7BCC2" font-size="12.5" text-anchor="middle">chat completions (gpt-5.4-mini)</text>
-<rect x="1315" y="410" width="330" height="88" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1480.0" y="432" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">NYC TLC dataset</text>
-<text x="1480.0" y="454" fill="#B7BCC2" font-size="12.5" text-anchor="middle">public parquet; read once by the</text>
-<text x="1480.0" y="472" fill="#B7BCC2" font-size="12.5" text-anchor="middle">module 01 seed. Data source only.</text>
-<path d="M287,252 L287,300" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="288.0" y="257.0" width="82.0" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="329.0" y="270.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">/api proxy</text>
-<path d="M180,362 L180,410" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="126.6" y="367.0" width="38.8" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="146.0" y="380.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">OTLP</text>
-<path d="M515,331 L560,331 L560,250 L620,250" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="508.0" y="287" width="118.0" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="567" y="300" fill="#B7BCC2" font-size="11.5" text-anchor="middle">SQL · TLS :8443</text>
-<path d="M515,438 L585,438 L585,262 L620,262" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="522.4" y="387" width="125.2" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="585" y="400" fill="#B7BCC2" font-size="11.5" text-anchor="middle">traces → otel db</text>
-<path d="M515,545 L620,541" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="497.7" y="522.0" width="139.6" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="567.5" y="535.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">INSERT trips · TLS</text>
-<path d="M515,690 L620,665" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="522.9" y="656.5" width="89.2" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="567.5" y="669.5" fill="#B7BCC2" font-size="11.5" text-anchor="middle">MCP · OAuth</text>
-<path d="M760,500 L760,418" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="686.6" y="442.0" width="146.8" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="760.0" y="455.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">logical replication</text>
-<path d="M760,330 L760,281" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="708.2" y="288.5" width="103.60000000000001" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="760.0" y="301.5" fill="#B7BCC2" font-size="11.5" text-anchor="middle">CDC rows ~60s</text>
-<path d="M1070,330 L1070,281" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="1018.2" y="288.5" width="103.60000000000001" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="1070.0" y="301.5" fill="#B7BCC2" font-size="11.5" text-anchor="middle">reads otel db</text>
-<path d="M1070,628 L1215,628 L1215,235 L1210,235" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="1181.2" y="457" width="67.6" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="1215" y="470" fill="#B7BCC2" font-size="11.5" text-anchor="middle">RBAC SQL</text>
-<path d="M360,300 L360,118 L1480,118 L1480,300" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="887.4" y="99" width="125.2" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="950" y="112" fill="#B7BCC2" font-size="11.5" text-anchor="middle">chat completions</text>
-<path d="M330,300 L330,96 L1430,96 L1430,195" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="661.4" y="77" width="197.20000000000002" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="760" y="90" fill="#B7BCC2" font-size="11.5" text-anchor="middle">chat traces (Langfuse SDK)</text>
-<path d="M1315,452 L1262,452 L1262,215 L1210,215" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="1221.0" y="292" width="82.0" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="1262" y="305" fill="#B7BCC2" font-size="11.5" text-anchor="middle">url() seed</text>
+<text x="30" y="44" fill="#EDEDED" font-size="22" font-weight="700">ClickHouse BUILD Workshop · Where each component runs</text>
+<text x="30" y="70" fill="#B7BCC2" font-size="13.5">Group components by location first. Follow the next diagram for the trip data path.</text>
+<rect x="30" y="110" width="430" height="480" rx="16" fill="#1B2531" stroke="#3E5A78" stroke-width="1.6" opacity="0.96"/>
+<text x="48" y="136" fill="#3E5A78" font-size="15" font-weight="700" letter-spacing="0.5">PARTICIPANT LAPTOP  ·  the NYC-taxi app runs here</text>
+<rect x="510" y="110" width="620" height="480" rx="16" fill="#211F14" stroke="#FAFF69" stroke-width="1.6" opacity="0.96"/>
+<text x="528" y="136" fill="#FAFF69" font-size="15" font-weight="700" letter-spacing="0.5">CLICKHOUSE CLOUD  ·  your trial org (you create all of this)</text>
+<rect x="1180" y="110" width="290" height="480" rx="16" fill="#1E1E22" stroke="#54545C" stroke-width="1.6" opacity="0.96"/>
+<text x="1198" y="136" fill="#54545C" font-size="15" font-weight="700" letter-spacing="0.5">THIRD-PARTY</text>
+<rect x="60" y="165" width="370" height="78" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="245.0" y="187" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Frontend + FastAPI</text>
+<text x="245.0" y="209" fill="#B7BCC2" font-size="14" text-anchor="middle">dashboards, chat, and API</text>
+<text x="245.0" y="227" fill="#B7BCC2" font-size="14" text-anchor="middle">runs with Docker Compose</text>
+<rect x="60" y="270" width="370" height="68" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="245.0" y="292" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Load generator</text>
+<text x="245.0" y="314" fill="#B7BCC2" font-size="14" text-anchor="middle">creates synthetic trip rows</text>
+<rect x="60" y="365" width="370" height="68" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="245.0" y="387" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">OpenTelemetry forwarder</text>
+<text x="245.0" y="409" fill="#B7BCC2" font-size="14" text-anchor="middle">sends app telemetry to ClickStack</text>
+<rect x="60" y="460" width="370" height="78" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="245.0" y="482" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Coding agent + clickhousectl</text>
+<text x="245.0" y="504" fill="#B7BCC2" font-size="14" text-anchor="middle">workshop commands, MCP,</text>
+<text x="245.0" y="522" fill="#B7BCC2" font-size="14" text-anchor="middle">and ClickHouse skills</text>
+<rect x="540" y="165" width="560" height="88" rx="12" fill="#26262B" stroke="#FAFF69" stroke-width="2"/>
+<text x="820.0" y="187" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">ClickHouse service</text>
+<text x="820.0" y="209" fill="#B7BCC2" font-size="14" text-anchor="middle">default.realtime_trips lands here</text>
+<text x="820.0" y="227" fill="#B7BCC2" font-size="14" text-anchor="middle">nyc_tlc_data.taxi_trips powers the app</text>
+<rect x="540" y="285" width="265" height="78" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="672.5" y="307" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Managed Postgres</text>
+<text x="672.5" y="329" fill="#B7BCC2" font-size="14" text-anchor="middle">public.realtime_trips</text>
+<rect x="835" y="285" width="265" height="78" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="967.5" y="307" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">ClickPipes</text>
+<text x="967.5" y="329" fill="#B7BCC2" font-size="14" text-anchor="middle">streams Postgres changes</text>
+<rect x="540" y="395" width="265" height="88" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="672.5" y="417" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Managed ClickStack</text>
+<text x="672.5" y="439" fill="#B7BCC2" font-size="14" text-anchor="middle">HyperDX traces, logs,</text>
+<text x="672.5" y="457" fill="#B7BCC2" font-size="14" text-anchor="middle">dashboards, and alerts</text>
+<rect x="835" y="395" width="265" height="88" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="967.5" y="417" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Agents + remote MCP</text>
+<text x="967.5" y="439" fill="#B7BCC2" font-size="14" text-anchor="middle">ask questions and let</text>
+<text x="967.5" y="457" fill="#B7BCC2" font-size="14" text-anchor="middle">the coding agent use tools</text>
+<rect x="1210" y="175" width="230" height="82" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="1325.0" y="197" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">OpenAI API</text>
+<text x="1325.0" y="219" fill="#B7BCC2" font-size="14" text-anchor="middle">chat completions</text>
+<rect x="1210" y="290" width="230" height="82" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="1325.0" y="312" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Langfuse Cloud</text>
+<text x="1325.0" y="334" fill="#B7BCC2" font-size="14" text-anchor="middle">chat traces and cost</text>
+<rect x="1210" y="405" width="230" height="92" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="1325.0" y="427" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">NYC TLC dataset</text>
+<text x="1325.0" y="449" fill="#B7BCC2" font-size="14" text-anchor="middle">one-time historical</text>
+<text x="1325.0" y="467" fill="#B7BCC2" font-size="14" text-anchor="middle">seed source</text>
+<path d="M460,565 L510,565" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
+<rect x="465.6" y="534" width="38.8" height="20" rx="4" fill="#17171A"/>
+<text x="485" y="548" fill="#B7BCC2" font-size="12.5" text-anchor="middle">uses</text>
+<path d="M1130,565 L1180,565" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
+<rect x="1132.0" y="534" width="46.0" height="20" rx="4" fill="#17171A"/>
+<text x="1155" y="548" fill="#B7BCC2" font-size="12.5" text-anchor="middle">calls</text>
 </svg>

--- a/workshops/build_workshop/playbook/public/workshop-architecture.svg
+++ b/workshops/build_workshop/playbook/public/workshop-architecture.svg
@@ -62,9 +62,6 @@
 <text x="1480.0" y="432" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">NYC TLC dataset</text>
 <text x="1480.0" y="454" fill="#B7BCC2" font-size="12.5" text-anchor="middle">public parquet; read once by the</text>
 <text x="1480.0" y="472" fill="#B7BCC2" font-size="12.5" text-anchor="middle">module 01 seed. Data source only.</text>
-<rect x="1315" y="530" width="330" height="74" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1480.0" y="552" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">Hosted LibreChat</text>
-<text x="1480.0" y="574" fill="#B7BCC2" font-size="12.5" text-anchor="middle">optional SRE chat · remote MCP</text>
 <path d="M287,252 L287,300" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
 <rect x="288.0" y="257.0" width="82.0" height="18" rx="4" fill="#17171A" opacity="0.92"/>
 <text x="329.0" y="270.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">/api proxy</text>

--- a/workshops/build_workshop/playbook/public/workshop-data-flow.svg
+++ b/workshops/build_workshop/playbook/public/workshop-data-flow.svg
@@ -1,105 +1,60 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1560" height="900" viewBox="0 0 1560 900" font-family="Inter, -apple-system, Segoe UI, Roboto, sans-serif">
-<rect x="0" y="0" width="1560" height="900" fill="#17171A"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="620" viewBox="0 0 1200 620" font-family="Inter, -apple-system, Segoe UI, Roboto, sans-serif">
+<rect x="0" y="0" width="1200" height="620" fill="#17171A"/>
 <defs><marker id="arrow" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L7,3 L0,6 Z" fill="#7E858E"/></marker></defs>
-<text x="30" y="44" fill="#EDEDED" font-size="22" font-weight="700">ClickHouse BUILD Workshop · Data flow</text>
-<text x="30" y="70" fill="#B7BCC2" font-size="13.5">How a row moves: seeded once, streamed continuously, then read and observed — all through your ClickHouse service.</text>
-<rect x="30" y="96" width="1500" height="96" rx="14" fill="#1C1C22" stroke="#3A3A45" stroke-width="1.3"/>
-<rect x="30" y="96" width="6" height="96" rx="3" fill="#FAFF69"/>
-<text x="52" y="126" fill="#EDEDED" font-size="14.5" font-weight="700">Seed</text>
-<text x="52" y="148" fill="#B7BCC2" font-size="11">one-time, module 01</text>
-<rect x="216" y="113" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="324.0" y="135" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">NYC TLC parquet</text>
-<text x="324.0" y="157" fill="#B7BCC2" font-size="12.5" text-anchor="middle">~3.2M rows, public</text>
-<rect x="928" y="113" width="216" height="62" rx="10" fill="#26262B" stroke="#FAFF69" stroke-width="2"/>
-<text x="1036.0" y="135" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">ClickHouse service</text>
-<text x="1036.0" y="157" fill="#B7BCC2" font-size="12.5" text-anchor="middle">nyc_tlc_data.taxi_trips</text>
-<path d="M432,144 L922,144" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="538.8" y="122.0" width="276.40000000000003" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="677.0" y="135.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">url() seed — one statement, module 01</text>
-<rect x="30" y="212" width="1500" height="110" rx="14" fill="#1C1C22" stroke="#3A3A45" stroke-width="1.3"/>
-<rect x="30" y="212" width="6" height="110" rx="3" fill="#FAFF69"/>
-<text x="52" y="242" fill="#EDEDED" font-size="14.5" font-weight="700">Live CDC</text>
-<text x="52" y="264" fill="#B7BCC2" font-size="11">continuous, module 03</text>
-<rect x="216" y="236" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="324.0" y="258" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">pg-trip-writer</text>
-<text x="324.0" y="280" fill="#B7BCC2" font-size="12.5" text-anchor="middle">synthetic trips</text>
-<rect x="572" y="236" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="680.0" y="258" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">Managed Postgres</text>
-<text x="680.0" y="280" fill="#B7BCC2" font-size="12.5" text-anchor="middle">public.realtime_trips</text>
-<rect x="928" y="236" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1036.0" y="258" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">ClickPipes</text>
-<text x="1036.0" y="280" fill="#B7BCC2" font-size="12.5" text-anchor="middle">Postgres CDC pipe</text>
-<rect x="1284" y="236" width="216" height="62" rx="10" fill="#26262B" stroke="#FAFF69" stroke-width="2"/>
-<text x="1392.0" y="258" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">ClickHouse service</text>
-<text x="1392.0" y="280" fill="#B7BCC2" font-size="12.5" text-anchor="middle">MV → taxi_trips</text>
-<path d="M432,267 L566,267" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="450.8" y="245.0" width="96.4" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="499.0" y="258.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">INSERT · TLS</text>
-<path d="M788,267 L922,267" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="810.4" y="245.0" width="89.2" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="855.0" y="258.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">replication</text>
-<path d="M1144,267 L1278,267" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="1159.2" y="245.0" width="103.60000000000001" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="1211.0" y="258.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">CDC rows ~60s</text>
-<rect x="30" y="342" width="1500" height="176" rx="14" fill="#1C1C22" stroke="#3A3A45" stroke-width="1.3"/>
-<rect x="30" y="342" width="6" height="176" rx="3" fill="#FAFF69"/>
-<text x="52" y="372" fill="#EDEDED" font-size="14.5" font-weight="700">Read</text>
-<text x="52" y="394" fill="#B7BCC2" font-size="11">modules 02, 04, 08</text>
-<rect x="216" y="364" width="216" height="62" rx="10" fill="#26262B" stroke="#FAFF69" stroke-width="2"/>
-<text x="324.0" y="386" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">ClickHouse service</text>
-<text x="324.0" y="408" fill="#B7BCC2" font-size="12.5" text-anchor="middle">nyc_tlc_data</text>
-<rect x="572" y="364" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="680.0" y="386" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">FastAPI</text>
-<text x="680.0" y="408" fill="#B7BCC2" font-size="12.5" text-anchor="middle">safe parameterized SQL</text>
-<rect x="928" y="364" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1036.0" y="386" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">Ops + Historical</text>
-<text x="1036.0" y="408" fill="#B7BCC2" font-size="12.5" text-anchor="middle">React dashboards</text>
-<path d="M432,395 L566,395" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="472.4" y="373.0" width="53.2" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="499.0" y="386.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">SELECT</text>
-<path d="M788,395 L922,395" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="814.0" y="373.0" width="82.0" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="855.0" y="386.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">GET /api/*</text>
-<rect x="572" y="446" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="680.0" y="468" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">in-app AI chat</text>
-<text x="680.0" y="490" fill="#B7BCC2" font-size="12.5" text-anchor="middle">guarded SELECT (module 08)</text>
-<rect x="928" y="446" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1036.0" y="468" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">ClickHouse Agents</text>
-<text x="1036.0" y="490" fill="#B7BCC2" font-size="12.5" text-anchor="middle">RBAC SQL (module 04)</text>
-<path d="M324.0,426 L324.0,477 L566,477" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="360.2" y="455" width="67.6" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="394.0" y="468" fill="#B7BCC2" font-size="11.5" text-anchor="middle">NL → SQL</text>
-<path d="M788,477 L922,477" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="821.2" y="455.0" width="67.6" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="855.0" y="468.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">RBAC SQL</text>
-<rect x="30" y="538" width="1500" height="176" rx="14" fill="#1C1C22" stroke="#3A3A45" stroke-width="1.3"/>
-<rect x="30" y="538" width="6" height="176" rx="3" fill="#FAFF69"/>
-<text x="52" y="568" fill="#EDEDED" font-size="14.5" font-weight="700">Observe</text>
-<text x="52" y="590" fill="#B7BCC2" font-size="11">modules 05, 06, 07</text>
-<rect x="216" y="560" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="324.0" y="582" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">backend spans</text>
-<text x="324.0" y="604" fill="#B7BCC2" font-size="12.5" text-anchor="middle">clickhouse.query + logs</text>
-<rect x="572" y="560" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="680.0" y="582" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">stateless OTel forwarder</text>
-<text x="680.0" y="604" fill="#B7BCC2" font-size="12.5" text-anchor="middle">local OTLP :4318</text>
-<rect x="928" y="560" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1036.0" y="582" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">otel db</text>
-<text x="1036.0" y="604" fill="#B7BCC2" font-size="12.5" text-anchor="middle">in your service</text>
-<rect x="1284" y="560" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1392.0" y="582" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">HyperDX UI</text>
-<text x="1392.0" y="604" fill="#B7BCC2" font-size="12.5" text-anchor="middle">search, traces, dashboards</text>
-<path d="M432,591 L566,591" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="479.6" y="569.0" width="38.8" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="499.0" y="582.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">OTLP</text>
-<path d="M788,591 L922,591" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="832.0" y="569.0" width="46.0" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="855.0" y="582.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">write</text>
-<path d="M1144,591 L1278,591" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<rect x="1191.6" y="569.0" width="38.8" height="18" rx="4" fill="#17171A" opacity="0.92"/>
-<text x="1211.0" y="582.0" fill="#B7BCC2" font-size="11.5" text-anchor="middle">read</text>
-<rect x="572" y="642" width="216" height="62" rx="10" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="680.0" y="664" fill="#EDEDED" font-size="15" font-weight="600" text-anchor="middle">coding agent</text>
-<text x="680.0" y="686" fill="#B7BCC2" font-size="12.5" text-anchor="middle">via ClickStack MCP</text>
-<path d="M680.0,642 L680.0,622" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<text x="922" y="676" fill="#B7BCC2" font-size="11.5">clickstack_search / save_dashboard / save_alert</text>
+<text x="30" y="44" fill="#EDEDED" font-size="22" font-weight="700">ClickHouse BUILD Workshop · A trip's path</text>
+<text x="30" y="70" fill="#B7BCC2" font-size="13.5">Read left to right: generate a trip, stream it into ClickHouse, then show it in the app.</text>
+<rect x="40" y="135" width="300" height="110" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="190.0" y="157" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Load generator</text>
+<text x="190.0" y="179" fill="#B7BCC2" font-size="14" text-anchor="middle">creates synthetic trips</text>
+<text x="190.0" y="197" fill="#B7BCC2" font-size="14" text-anchor="middle">on your laptop</text>
+<circle cx="60" cy="155" r="12" fill="#FAFF69"/>
+<text x="60" y="159" fill="#17171A" font-size="11" font-weight="700" text-anchor="middle">1</text>
+<rect x="450" y="135" width="300" height="110" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="600.0" y="157" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Managed Postgres</text>
+<text x="600.0" y="179" fill="#B7BCC2" font-size="14" text-anchor="middle">source table:</text>
+<text x="600.0" y="197" fill="#B7BCC2" font-size="14" text-anchor="middle">public.realtime_trips</text>
+<circle cx="470" cy="155" r="12" fill="#FAFF69"/>
+<text x="470" y="159" fill="#17171A" font-size="11" font-weight="700" text-anchor="middle">2</text>
+<rect x="860" y="135" width="300" height="110" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="1010.0" y="157" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">ClickPipes</text>
+<text x="1010.0" y="179" fill="#B7BCC2" font-size="14" text-anchor="middle">streams each change</text>
+<text x="1010.0" y="197" fill="#B7BCC2" font-size="14" text-anchor="middle">with Postgres CDC</text>
+<circle cx="880" cy="155" r="12" fill="#FAFF69"/>
+<text x="880" y="159" fill="#17171A" font-size="11" font-weight="700" text-anchor="middle">3</text>
+<rect x="860" y="345" width="300" height="110" rx="12" fill="#26262B" stroke="#FAFF69" stroke-width="2"/>
+<text x="1010.0" y="367" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">ClickHouse</text>
+<text x="1010.0" y="389" fill="#B7BCC2" font-size="14" text-anchor="middle">first landing table:</text>
+<text x="1010.0" y="407" fill="#B7BCC2" font-size="14" text-anchor="middle">default.realtime_trips</text>
+<circle cx="880" cy="365" r="12" fill="#FAFF69"/>
+<text x="880" y="369" fill="#17171A" font-size="11" font-weight="700" text-anchor="middle">4</text>
+<rect x="450" y="345" width="300" height="110" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="600.0" y="367" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Materialized view</text>
+<text x="600.0" y="389" fill="#B7BCC2" font-size="14" text-anchor="middle">moves new rows into</text>
+<text x="600.0" y="407" fill="#B7BCC2" font-size="14" text-anchor="middle">nyc_tlc_data.taxi_trips</text>
+<circle cx="470" cy="365" r="12" fill="#FAFF69"/>
+<text x="470" y="369" fill="#17171A" font-size="11" font-weight="700" text-anchor="middle">5</text>
+<rect x="40" y="345" width="300" height="110" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
+<text x="190.0" y="367" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Frontend + FastAPI</text>
+<text x="190.0" y="389" fill="#B7BCC2" font-size="14" text-anchor="middle">reads taxi_trips for</text>
+<text x="190.0" y="407" fill="#B7BCC2" font-size="14" text-anchor="middle">the live dashboards</text>
+<circle cx="60" cy="365" r="12" fill="#FAFF69"/>
+<text x="60" y="369" fill="#17171A" font-size="11" font-weight="700" text-anchor="middle">6</text>
+<path d="M340,190 L443,190" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
+<rect x="368.4" y="153" width="53.2" height="20" rx="4" fill="#17171A"/>
+<text x="395" y="167" fill="#B7BCC2" font-size="12.5" text-anchor="middle">INSERT</text>
+<path d="M750,190 L853,190" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
+<rect x="789.2" y="153" width="31.6" height="20" rx="4" fill="#17171A"/>
+<text x="805" y="167" fill="#B7BCC2" font-size="12.5" text-anchor="middle">CDC</text>
+<path d="M1010,245 L1010,338" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
+<rect x="969.0" y="288" width="82.0" height="20" rx="4" fill="#17171A"/>
+<text x="1010" y="302" fill="#B7BCC2" font-size="12.5" text-anchor="middle">lands here</text>
+<path d="M860,400 L757,400" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
+<rect x="782.0" y="363" width="46.0" height="20" rx="4" fill="#17171A"/>
+<text x="805" y="377" fill="#B7BCC2" font-size="12.5" text-anchor="middle">feeds</text>
+<path d="M450,400 L347,400" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
+<rect x="372.0" y="363" width="46.0" height="20" rx="4" fill="#17171A"/>
+<text x="395" y="377" fill="#B7BCC2" font-size="12.5" text-anchor="middle">reads</text>
+<rect x="40" y="505" width="1120" height="75" rx="12" fill="#1C1C22" stroke="#3A3A45" stroke-width="1.3"/>
+<text x="65" y="535" fill="#FAFF69" font-size="13" font-weight="700">What the other workshop tools do</text>
+<text x="65" y="560" fill="#B7BCC2" font-size="12.5">ClickStack observes the app · ClickHouse Agents answers data questions · Langfuse traces the chat</text>
 </svg>

--- a/workshops/build_workshop/playbook/public/workshop-data-flow.svg
+++ b/workshops/build_workshop/playbook/public/workshop-data-flow.svg
@@ -2,41 +2,41 @@
 <rect x="0" y="0" width="1200" height="620" fill="#17171A"/>
 <defs><marker id="arrow" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L7,3 L0,6 Z" fill="#7E858E"/></marker></defs>
 <text x="30" y="44" fill="#EDEDED" font-size="22" font-weight="700">ClickHouse BUILD Workshop · A trip's path</text>
-<text x="30" y="70" fill="#B7BCC2" font-size="13.5">Read left to right: generate a trip, stream it into ClickHouse, then show it in the app.</text>
+<text x="30" y="70" fill="#B7BCC2" font-size="13.5">Follow steps 1–6: across the top, then back across the bottom.</text>
 <rect x="40" y="135" width="300" height="110" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="190.0" y="157" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Load generator</text>
-<text x="190.0" y="179" fill="#B7BCC2" font-size="14" text-anchor="middle">creates synthetic trips</text>
-<text x="190.0" y="197" fill="#B7BCC2" font-size="14" text-anchor="middle">on your laptop</text>
+<text x="190.0" y="157" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">Load generator</text>
+<text x="190.0" y="179" fill="#B7BCC2" font-size="14.5" text-anchor="middle">creates synthetic trips</text>
+<text x="190.0" y="197" fill="#B7BCC2" font-size="14.5" text-anchor="middle">on your laptop</text>
 <circle cx="60" cy="155" r="12" fill="#FAFF69"/>
 <text x="60" y="159" fill="#17171A" font-size="11" font-weight="700" text-anchor="middle">1</text>
 <rect x="450" y="135" width="300" height="110" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="600.0" y="157" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Managed Postgres</text>
-<text x="600.0" y="179" fill="#B7BCC2" font-size="14" text-anchor="middle">source table:</text>
-<text x="600.0" y="197" fill="#B7BCC2" font-size="14" text-anchor="middle">public.realtime_trips</text>
+<text x="600.0" y="157" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">Managed Postgres</text>
+<text x="600.0" y="179" fill="#B7BCC2" font-size="14.5" text-anchor="middle">source table:</text>
+<text x="600.0" y="197" fill="#B7BCC2" font-size="14.5" text-anchor="middle">public.realtime_trips</text>
 <circle cx="470" cy="155" r="12" fill="#FAFF69"/>
 <text x="470" y="159" fill="#17171A" font-size="11" font-weight="700" text-anchor="middle">2</text>
 <rect x="860" y="135" width="300" height="110" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="1010.0" y="157" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">ClickPipes</text>
-<text x="1010.0" y="179" fill="#B7BCC2" font-size="14" text-anchor="middle">streams each change</text>
-<text x="1010.0" y="197" fill="#B7BCC2" font-size="14" text-anchor="middle">with Postgres CDC</text>
+<text x="1010.0" y="157" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">ClickPipes</text>
+<text x="1010.0" y="179" fill="#B7BCC2" font-size="14.5" text-anchor="middle">streams each change</text>
+<text x="1010.0" y="197" fill="#B7BCC2" font-size="14.5" text-anchor="middle">with Postgres CDC</text>
 <circle cx="880" cy="155" r="12" fill="#FAFF69"/>
 <text x="880" y="159" fill="#17171A" font-size="11" font-weight="700" text-anchor="middle">3</text>
 <rect x="860" y="345" width="300" height="110" rx="12" fill="#26262B" stroke="#FAFF69" stroke-width="2"/>
-<text x="1010.0" y="367" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">ClickHouse</text>
-<text x="1010.0" y="389" fill="#B7BCC2" font-size="14" text-anchor="middle">first landing table:</text>
-<text x="1010.0" y="407" fill="#B7BCC2" font-size="14" text-anchor="middle">default.realtime_trips</text>
+<text x="1010.0" y="367" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">ClickHouse</text>
+<text x="1010.0" y="389" fill="#B7BCC2" font-size="14.5" text-anchor="middle">first landing table:</text>
+<text x="1010.0" y="407" fill="#B7BCC2" font-size="14.5" text-anchor="middle">default.realtime_trips</text>
 <circle cx="880" cy="365" r="12" fill="#FAFF69"/>
 <text x="880" y="369" fill="#17171A" font-size="11" font-weight="700" text-anchor="middle">4</text>
 <rect x="450" y="345" width="300" height="110" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="600.0" y="367" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Materialized view</text>
-<text x="600.0" y="389" fill="#B7BCC2" font-size="14" text-anchor="middle">moves new rows into</text>
-<text x="600.0" y="407" fill="#B7BCC2" font-size="14" text-anchor="middle">nyc_tlc_data.taxi_trips</text>
+<text x="600.0" y="367" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">Materialized view</text>
+<text x="600.0" y="389" fill="#B7BCC2" font-size="14.5" text-anchor="middle">moves new rows into</text>
+<text x="600.0" y="407" fill="#B7BCC2" font-size="14.5" text-anchor="middle">nyc_tlc_data.taxi_trips</text>
 <circle cx="470" cy="365" r="12" fill="#FAFF69"/>
 <text x="470" y="369" fill="#17171A" font-size="11" font-weight="700" text-anchor="middle">5</text>
 <rect x="40" y="345" width="300" height="110" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<text x="190.0" y="367" fill="#EDEDED" font-size="17" font-weight="600" text-anchor="middle">Frontend + FastAPI</text>
-<text x="190.0" y="389" fill="#B7BCC2" font-size="14" text-anchor="middle">reads taxi_trips for</text>
-<text x="190.0" y="407" fill="#B7BCC2" font-size="14" text-anchor="middle">the live dashboards</text>
+<text x="190.0" y="367" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">Frontend + FastAPI</text>
+<text x="190.0" y="389" fill="#B7BCC2" font-size="14.5" text-anchor="middle">reads taxi_trips for</text>
+<text x="190.0" y="407" fill="#B7BCC2" font-size="14.5" text-anchor="middle">the live dashboards</text>
 <circle cx="60" cy="365" r="12" fill="#FAFF69"/>
 <text x="60" y="369" fill="#17171A" font-size="11" font-weight="700" text-anchor="middle">6</text>
 <path d="M340,190 L443,190" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>

--- a/workshops/build_workshop/playbook/public/workshop-module-flow.svg
+++ b/workshops/build_workshop/playbook/public/workshop-module-flow.svg
@@ -1,8 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1756" height="568" viewBox="0 0 1756 568" font-family="Inter, -apple-system, Segoe UI, Roboto, sans-serif">
-<rect x="0" y="0" width="1756" height="568" fill="#17171A"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="1756" height="402" viewBox="0 0 1756 402" font-family="Inter, -apple-system, Segoe UI, Roboto, sans-serif">
+<rect x="0" y="0" width="1756" height="402" fill="#17171A"/>
 <defs><marker id="arrow" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L7,3 L0,6 Z" fill="#7E858E"/></marker></defs>
 <text x="40" y="48" fill="#EDEDED" font-size="20" font-weight="700">ClickHouse BUILD Workshop · Module flow</text>
-<text x="40" y="70" fill="#B7BCC2" font-size="13">~2h30 core + optional 06b · only module 07 switches to a fault branch</text>
+<text x="40" y="70" fill="#B7BCC2" font-size="13">~2h30 hands-on · only module 07 switches to a fault branch</text>
 <rect x="40" y="92" width="300" height="96" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
 <rect x="40" y="92" width="5" height="96" rx="2.5" fill="#FAFF69"/>
 <text x="58" y="118" fill="#EDEDED" font-size="14.5" font-weight="700">00 Setup</text>
@@ -47,28 +47,22 @@
 <text x="1090" y="328" fill="#B7BCC2" font-size="12.5">builds dashboard + alert</text>
 <rect x="728" y="258" width="300" height="96" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
 <rect x="728" y="258" width="5" height="96" rx="2.5" fill="#FAFF69"/>
-<text x="746" y="284" fill="#EDEDED" font-size="14.5" font-weight="700">06b Hosted LibreChat</text>
-<text x="1014" y="284" fill="#FAFF69" font-size="12.5" font-weight="600" text-anchor="end">optional · 15 min</text>
-<text x="746" y="310" fill="#B7BCC2" font-size="12.5">remote ClickStack + GitHub MCP</text>
-<text x="746" y="328" fill="#B7BCC2" font-size="12.5">chat-native SRE workflow</text>
+<text x="746" y="284" fill="#EDEDED" font-size="14.5" font-weight="700">07 Test, fail, and fix</text>
+<text x="1014" y="284" fill="#FAFF69" font-size="12.5" font-weight="600" text-anchor="end">20 min</text>
+<text x="746" y="310" fill="#B7BCC2" font-size="12.5">inject a fault, diagnose</text>
+<text x="746" y="328" fill="#B7BCC2" font-size="12.5">with the AI SRE, fix it</text>
 <rect x="384" y="258" width="300" height="96" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
 <rect x="384" y="258" width="5" height="96" rx="2.5" fill="#FAFF69"/>
-<text x="402" y="284" fill="#EDEDED" font-size="14.5" font-weight="700">07 Test, fail, and fix</text>
-<text x="670" y="284" fill="#FAFF69" font-size="12.5" font-weight="600" text-anchor="end">20 min</text>
-<text x="402" y="310" fill="#B7BCC2" font-size="12.5">inject a fault, diagnose</text>
-<text x="402" y="328" fill="#B7BCC2" font-size="12.5">with the AI SRE, fix it</text>
+<text x="402" y="284" fill="#EDEDED" font-size="14.5" font-weight="700">08 Chat + Langfuse</text>
+<text x="670" y="284" fill="#FAFF69" font-size="12.5" font-weight="600" text-anchor="end">15 min</text>
+<text x="402" y="310" fill="#B7BCC2" font-size="12.5">in-app AI chat,</text>
+<text x="402" y="328" fill="#B7BCC2" font-size="12.5">every turn traced</text>
 <rect x="40" y="258" width="300" height="96" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
 <rect x="40" y="258" width="5" height="96" rx="2.5" fill="#FAFF69"/>
-<text x="58" y="284" fill="#EDEDED" font-size="14.5" font-weight="700">08 Chat + Langfuse</text>
-<text x="326" y="284" fill="#FAFF69" font-size="12.5" font-weight="600" text-anchor="end">15 min</text>
-<text x="58" y="310" fill="#B7BCC2" font-size="12.5">in-app AI chat,</text>
-<text x="58" y="328" fill="#B7BCC2" font-size="12.5">every turn traced</text>
-<rect x="40" y="424" width="300" height="96" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
-<rect x="40" y="424" width="5" height="96" rx="2.5" fill="#FAFF69"/>
-<text x="58" y="450" fill="#EDEDED" font-size="14.5" font-weight="700">09 Wrap-up</text>
-<text x="326" y="450" fill="#FAFF69" font-size="12.5" font-weight="600" text-anchor="end">10 min</text>
-<text x="58" y="476" fill="#B7BCC2" font-size="12.5">running prototype,</text>
-<text x="58" y="494" fill="#B7BCC2" font-size="12.5">take it home</text>
+<text x="58" y="284" fill="#EDEDED" font-size="14.5" font-weight="700">09 Wrap-up</text>
+<text x="326" y="284" fill="#FAFF69" font-size="12.5" font-weight="600" text-anchor="end">10 min</text>
+<text x="58" y="310" fill="#B7BCC2" font-size="12.5">running prototype,</text>
+<text x="58" y="328" fill="#B7BCC2" font-size="12.5">take it home</text>
 <path d="M340,140.0 L378,140.0" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
 <path d="M684,140.0 L722,140.0" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
 <path d="M1028,140.0 L1066,140.0" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
@@ -78,6 +72,5 @@
 <path d="M1072,306.0 L1034,306.0" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
 <path d="M728,306.0 L690,306.0" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
 <path d="M384,306.0 L346,306.0" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
-<path d="M190.0,354 L190.0,418" fill="none" stroke="#7E858E" stroke-width="1.6" marker-end="url(#arrow)"/>
 <text x="40" y="228.0" fill="#B7BCC2" font-size="12" font-style="italic">After module 03: historical + live data both flowing into your Cloud service.</text>
 </svg>

--- a/workshops/build_workshop/scripts/check-docs.sh
+++ b/workshops/build_workshop/scripts/check-docs.sh
@@ -29,6 +29,22 @@ fail_if_found \
   '(comment|uncomment).*(sql|variant)|(run|execute|open).*(db/cloud|\.sql file)' \
   "${CONTENT}/learner"
 
+if grep -RInE --exclude='06b-ai-sre-librechat.mdx' \
+  '06b|LibreChat' "${CONTENT}"; then
+  echo "ERROR: archived Module 06b must not appear in the active workshop journey" >&2
+  exit 1
+fi
+
+fail_if_found \
+  "active workshop summaries and diagrams must not include archived Module 06b" \
+  '06b|LibreChat' \
+  "${ROOT}/README.md" \
+  "${ROOT}/docs/diagrams/gen_diagrams.py" \
+  "${ROOT}/docs/diagrams/workshop-module-flow.svg" \
+  "${ROOT}/docs/diagrams/workshop-architecture.svg" \
+  "${ROOT}/playbook/public/workshop-module-flow.svg" \
+  "${ROOT}/playbook/public/workshop-architecture.svg"
+
 fail_if_found \
   "workshop material must not direct users to local managed-service substitutes" \
   'PGHOST=postgres|localhost:3090|docker-compose\.librechat|local `mcp-clickhouse`|start (a |the )?local (Postgres|ClickHouse|LibreChat|HyperDX)|using (a |the )?local (Postgres|ClickHouse)' \
@@ -68,6 +84,16 @@ require_fixed \
   "learner setup must switch to the production workshop branch" \
   'git switch build-workshop-v1' \
   "${CONTENT}/learner/00-setup.mdx"
+
+require_fixed \
+  "the former learner Module 06b page must remain clearly archived" \
+  'Module 06b is no longer part of the workshop.' \
+  "${CONTENT}/learner/06b-ai-sre-librechat.mdx"
+
+require_fixed \
+  "the former instructor Module 06b page must remain clearly archived" \
+  'Module 06b is no longer part of the run of show.' \
+  "${CONTENT}/instructor/06b-ai-sre-librechat.mdx"
 
 require_count() {
   local description=$1

--- a/workshops/build_workshop/scripts/check-docs.sh
+++ b/workshops/build_workshop/scripts/check-docs.sh
@@ -102,6 +102,22 @@ require_fixed \
   '[Module 07](/docs/instructor/07-break-and-fix)' \
   "${CONTENT}/instructor/06b-ai-sre-librechat.mdx"
 
+for file in \
+  "${ROOT}/app/README.md" \
+  "${ROOT}/app/OBSERVABILITY.md" \
+  "${CONTENT}/learner/05-clickstack.mdx" \
+  "${CONTENT}/instructor/05-clickstack.mdx"; do
+  require_fixed \
+    "ClickStack overlay startup must rebuild the frontend telemetry bundle" \
+    'docker-compose.otel.yml up -d --build' \
+    "${file}"
+done
+
+require_fixed \
+  "the optional container-log overlay must also rebuild the frontend" \
+  '--profile container-logs up -d --build' \
+  "${ROOT}/app/OBSERVABILITY.md"
+
 require_count() {
   local description=$1
   local expected=$2

--- a/workshops/build_workshop/scripts/check-docs.sh
+++ b/workshops/build_workshop/scripts/check-docs.sh
@@ -30,8 +30,8 @@ fail_if_found \
   "${CONTENT}/learner"
 
 if grep -RInE --exclude='06b-ai-sre-librechat.mdx' \
-  '06b|LibreChat' "${CONTENT}"; then
-  echo "ERROR: archived Module 06b must not appear in the active workshop journey" >&2
+  '06a|06b|LibreChat' "${CONTENT}"; then
+  echo "ERROR: active workshop must use Module 06 and exclude archived Module 06b" >&2
   exit 1
 fi
 
@@ -39,6 +39,8 @@ fail_if_found \
   "active workshop summaries and diagrams must not include archived Module 06b" \
   '06b|LibreChat' \
   "${ROOT}/README.md" \
+  "${ROOT}/app/README.md" \
+  "${ROOT}/app/WORKSHOP_CHANGES.md" \
   "${ROOT}/docs/diagrams/gen_diagrams.py" \
   "${ROOT}/docs/diagrams/workshop-module-flow.svg" \
   "${ROOT}/docs/diagrams/workshop-architecture.svg" \
@@ -93,6 +95,11 @@ require_fixed \
 require_fixed \
   "the former instructor Module 06b page must remain clearly archived" \
   'Module 06b is no longer part of the run of show.' \
+  "${CONTENT}/instructor/06b-ai-sre-librechat.mdx"
+
+require_fixed \
+  "the archived instructor page must link to active Module 07" \
+  '[Module 07](/docs/instructor/07-break-and-fix)' \
   "${CONTENT}/instructor/06b-ai-sre-librechat.mdx"
 
 require_count() {


### PR DESCRIPTION
## Promotion

Promotes the dev-verified workshop release to production.

- archives Module 06b from the active learner and instructor journey
- routes Module 06 directly to Module 07
- runs the ClickStack collector before enabling Managed ClickStack
- simplifies architecture and trip-flow diagrams with exact Postgres and ClickHouse table names
- keeps warned historical 06b routes available but unlisted

## Dev verification

- dev deployment workflow passed Linux CI, Windows CI, immutable image deploy, and public-route verification
- `https://dev-workshop.demohouse.cloud/docs` returns 200 without an auth redirect
- active docs contain no 06b/LibreChat navigation
- archived learner 06b URL returns 200 with warning and Module 07 link
- ClickStack displays collector Step 1, Managed ClickStack Step 2, and `up -d --build`
- simplified diagram renders cleanly with no console errors