### PR TITLE
fix(workshop): expose Polymarket on the hub

### DIFF
--- a/workshops/build_workshop/README.md
+++ b/workshops/build_workshop/README.md
@@ -1,4 +1,4 @@
-# ClickHouse Cloud use-case workshops
+# Build Series: Solutions on ClickHouse Cloud
 
 This site now carries two dedicated use cases:
 

--- a/workshops/build_workshop/playbook/README.md
+++ b/workshops/build_workshop/playbook/README.md
@@ -1,4 +1,4 @@
-# ClickHouse Cloud workshop playbook
+# Build Series: Solutions on ClickHouse Cloud
 
 The published playbook offers two dedicated ClickHouse Cloud use cases:
 

--- a/workshops/build_workshop/playbook/content/docs/index.mdx
+++ b/workshops/build_workshop/playbook/content/docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: ClickHouse Cloud workshops
+title: "Build Series: Solutions on ClickHouse Cloud"
 description: Choose a use case, then follow its learner or instructor track.
 ---
 

--- a/workshops/build_workshop/playbook/public/workshop-architecture.svg
+++ b/workshops/build_workshop/playbook/public/workshop-architecture.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="650" viewBox="0 0 1200 650" font-family="Inter, -apple-system, Segoe UI, Roboto, sans-serif">
 <rect x="0" y="0" width="1200" height="650" fill="#17171A"/>
 <defs><marker id="arrow" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L7,3 L0,6 Z" fill="#7E858E"/></marker></defs>
-<text x="30" y="44" fill="#EDEDED" font-size="22" font-weight="700">ClickHouse BUILD Workshop · Where each component runs</text>
+<text x="30" y="44" fill="#EDEDED" font-size="22" font-weight="700">ClickHouse Build Series · Where each component runs</text>
 <text x="30" y="70" fill="#B7BCC2" font-size="13.5">Grouped by location; no data direction is implied. Follow the next diagram for the trip path.</text>
 <rect x="30" y="110" width="330" height="480" rx="16" fill="#1B2531" stroke="#3E5A78" stroke-width="1.6" opacity="0.96"/>
 <text x="48" y="136" fill="#B7BCC2" font-size="16" font-weight="700" letter-spacing="0.5">PARTICIPANT LAPTOP · local app + tools</text>

--- a/workshops/build_workshop/playbook/public/workshop-data-flow.svg
+++ b/workshops/build_workshop/playbook/public/workshop-data-flow.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="620" viewBox="0 0 1200 620" font-family="Inter, -apple-system, Segoe UI, Roboto, sans-serif">
 <rect x="0" y="0" width="1200" height="620" fill="#17171A"/>
 <defs><marker id="arrow" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L7,3 L0,6 Z" fill="#7E858E"/></marker></defs>
-<text x="30" y="44" fill="#EDEDED" font-size="22" font-weight="700">ClickHouse BUILD Workshop · A trip's path</text>
+<text x="30" y="44" fill="#EDEDED" font-size="22" font-weight="700">ClickHouse Build Series · A trip's path</text>
 <text x="30" y="70" fill="#B7BCC2" font-size="13.5">Follow steps 1–6: across the top, then back across the bottom.</text>
 <rect x="40" y="135" width="300" height="110" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
 <text x="190.0" y="157" fill="#EDEDED" font-size="18" font-weight="600" text-anchor="middle">Load generator</text>

--- a/workshops/build_workshop/playbook/public/workshop-module-flow.svg
+++ b/workshops/build_workshop/playbook/public/workshop-module-flow.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1756" height="402" viewBox="0 0 1756 402" font-family="Inter, -apple-system, Segoe UI, Roboto, sans-serif">
 <rect x="0" y="0" width="1756" height="402" fill="#17171A"/>
 <defs><marker id="arrow" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L7,3 L0,6 Z" fill="#7E858E"/></marker></defs>
-<text x="40" y="48" fill="#EDEDED" font-size="20" font-weight="700">ClickHouse BUILD Workshop · Module flow</text>
+<text x="40" y="48" fill="#EDEDED" font-size="20" font-weight="700">ClickHouse Build Series · Module flow</text>
 <text x="40" y="70" fill="#B7BCC2" font-size="13">~2h30 hands-on · only module 07 switches to a fault branch</text>
 <rect x="40" y="92" width="300" height="96" rx="12" fill="#26262B" stroke="#4C4C55" stroke-width="1.3"/>
 <rect x="40" y="92" width="5" height="96" rx="2.5" fill="#FAFF69"/>

--- a/workshops/build_workshop/playbook/src/app/build-workshop/page.tsx
+++ b/workshops/build_workshop/playbook/src/app/build-workshop/page.tsx
@@ -8,7 +8,7 @@ import '../landing.css';
 // base-path-aware.
 
 export const metadata: Metadata = {
-  title: 'Build it, end to end — ClickHouse BUILD Workshop',
+  title: 'AI SRE with NYC taxi data | ClickHouse Build Series',
   description:
     'A three-hour, hands-on workshop: your own AI coding agent takes a real analytics app end to end on ClickHouse Cloud — real-time CDC, conversational BI, observability, an AI SRE, and traced AI chat.',
 };
@@ -21,7 +21,7 @@ export default function LandingPage() {
         <div className="wrap">
           <div className="hero-grid">
             <div>
-              <p className="eyebrow"><span className="tick">ClickHouse</span>{' '} BUILD Workshop</p>
+              <p className="eyebrow"><span className="tick">ClickHouse</span>{' '} Build Series</p>
               <h1>Build it,<br /><span className="ai">end to end.</span></h1>
               <p className="hero-sub">
                 In one three-hour sitting, you take a real analytics app live on ClickHouse Cloud —
@@ -340,7 +340,7 @@ export default function LandingPage() {
       {/* ===================== FOOTER ===================== */}
       <footer>
         <div className="wrap">
-          <div className="brand">ClickHouse <b>BUILD</b> Workshop — Build AI with AI</div>
+          <div className="brand">ClickHouse <b>Build Series</b> · Solutions on ClickHouse Cloud</div>
           <div className="links">
             <Link href="/docs">Playbook</Link>
             <a href="https://clickhouse.com/cloud">ClickHouse Cloud</a>

--- a/workshops/build_workshop/playbook/src/app/hub.css
+++ b/workshops/build_workshop/playbook/src/app/hub.css
@@ -30,7 +30,8 @@
 
 .hub .grid-section { padding-block: clamp(40px, 6vw, 72px); }
 .hub .eyebrow { font-family: var(--mono); font-size: 12px; letter-spacing: .22em; text-transform: uppercase; color: var(--muted); margin: 0 0 22px; }
-.hub .grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+.hub .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+@media (max-width: 980px) { .hub .grid { grid-template-columns: repeat(2, 1fr); } }
 @media (max-width: 760px) { .hub .grid { grid-template-columns: 1fr; } }
 
 .hub .card { display: flex; flex-direction: column; gap: 14px; background: var(--ink-2); border: 1px solid var(--line-d); border-radius: 16px; padding: 26px 24px 24px; transition: transform .16s ease, border-color .16s ease, box-shadow .16s ease; }

--- a/workshops/build_workshop/playbook/src/app/page.tsx
+++ b/workshops/build_workshop/playbook/src/app/page.tsx
@@ -34,7 +34,7 @@ export default function WorkshopsHub() {
             <span className="brand-sub">Workshops</span>
           </div>
           <h1>Pick a workshop.<br />Start <span className="ai">building.</span></h1>
-          <p className="lede">Hands-on ClickHouse labs — from a 90-minute analytics sprint to a full afternoon building a real-time, AI-assisted app. Each runs on your own free ClickHouse Cloud trial.</p>
+          <p className="lede">Hands-on ClickHouse labs, from public live-data analytics to an AI-assisted incident workflow. Each runs on your own free ClickHouse Cloud trial.</p>
         </div>
       </header>
 
@@ -42,13 +42,22 @@ export default function WorkshopsHub() {
         <div className="wrap">
           <p className="eyebrow">Available workshops</p>
           <div className="grid">
-            <Link className="card" href="/build-workshop">
+            <Link className="card" href="/docs/ai-sre">
               <div className="card-meta"><span>3 hours</span><span className="dot" aria-hidden="true"></span><span>Intermediate</span></div>
-              <div className="card-title">Build AI with AI</div>
-              <div className="card-tagline">Build it, end to end.</div>
-              <p className="card-blurb">In one three-hour sitting, take a real analytics app live on ClickHouse Cloud with your own AI coding agent — real-time CDC, conversational BI, observability, an AI SRE, and traced AI chat.</p>
+              <div className="card-title">AI SRE with NYC taxi data</div>
+              <div className="card-tagline">Build it, observe it, then repair it.</div>
+              <p className="card-blurb">Take a real analytics app live on ClickHouse Cloud with real-time CDC, conversational BI, observability, an AI SRE, and traced AI chat.</p>
               <div className="tags"><span className="tag">CDC</span><span className="tag">Agents</span><span className="tag">ClickStack</span><span className="tag">Langfuse</span></div>
-              <span className="card-cta">Open workshop <span className="arrow">→</span></span>
+              <span className="card-cta">Open AI SRE track <span className="arrow">→</span></span>
+            </Link>
+
+            <Link className="card" href="/docs/polymarket">
+              <div className="card-meta"><span>2 hours 10 minutes</span><span className="dot" aria-hidden="true"></span><span>Intermediate</span></div>
+              <div className="card-title">Polymarket real-time analytics</div>
+              <div className="card-tagline">Watch a public market move live.</div>
+              <p className="card-blurb">Stream public prediction-market data into ClickHouse Cloud, maintain one-minute aggregates, investigate movement, and publish a market pulse dashboard.</p>
+              <div className="tags"><span className="tag">Streaming</span><span className="tag">Materialized Views</span><span className="tag">Dashboards</span><span className="tag">Public APIs</span></div>
+              <span className="card-cta">Open Polymarket track <span className="arrow">→</span></span>
             </Link>
 
             <a className="card" href={`${basePath}/rta-mini/index.html`}>

--- a/workshops/build_workshop/playbook/src/components/logo.tsx
+++ b/workshops/build_workshop/playbook/src/components/logo.tsx
@@ -19,7 +19,7 @@ export function Logo() {
         aria-hidden="true"
         style={{ width: 1, height: 18, background: 'var(--color-fd-border)' }}
       />
-      <span className="font-semibold tracking-tight">BUILD Workshop</span>
+      <span className="font-semibold tracking-tight">Build Series</span>
       <span className="sr-only">{appName}</span>
     </span>
   );

--- a/workshops/build_workshop/playbook/src/lib/shared.ts
+++ b/workshops/build_workshop/playbook/src/lib/shared.ts
@@ -1,4 +1,4 @@
-export const appName = 'ClickHouse BUILD Workshop';
+export const appName = 'Build Series: Solutions on ClickHouse Cloud';
 export const docsRoute = '/docs';
 export const docsImageRoute = '/og/docs';
 export const docsContentRoute = '/llms.mdx/docs';


### PR DESCRIPTION
## Summary
- show AI SRE and Polymarket as separate cards on the workshop domain root
- link each card directly to its dedicated track landing
- retain the existing Real-Time Market Analytics workshop card
- use a responsive three/two/one-column card grid

## Verification
- TypeScript check passed
- production build passed
- desktop and mobile browser QA passed
- all three card labels and hrefs verified; no console errors