### PR TITLE
Ignore Agent Arena local run state

### DIFF
--- a/workshops/agent_arena/.gitignore
+++ b/workshops/agent_arena/.gitignore
@@ -42,8 +42,12 @@ coverage/
 *.tfvars
 
 # ---- App-generated ----
-schema/schema_context.md   # regenerated from system.columns
-.run/                      # transient harness run/status + temp models-file
+# regenerated from system.columns
+schema/schema_context.md
+# transient harness run/status + temp models-file
+.run/
+# local workshop-review completion marker
+reviewed.json
 
 # ---- MkDocs (workshop guide) ----
 


### PR DESCRIPTION
## Summary
- fix the Agent Arena app-generated ignore rules so inline comments do not become part of the patterns
- ignore `.run/`, regenerated schema context, and the local workshop review marker

This keeps credentials and run/review state local now that `ClickHouse_Demos/workshops/agent_arena` is the single source of truth.

## Verification
- `git check-ignore` matches `.env`, `.run/`, `.venv/`, and `reviewed.json`
- Agent Arena: 2 frontend tests and 81 Python tests passed; production build succeeded