### PR TITLE
fix(postgres-migration): IMPORT FOREIGN SCHEMA user mapping, and the reconcile pass condition

### DIFF
--- a/workshops/postgres_migration/sql/05_reconcile.sql
+++ b/workshops/postgres_migration/sql/05_reconcile.sql
@@ -1,9 +1,16 @@
 -- 05_reconcile.sql
 -- Run identically on SOURCE and TARGET, capture both outputs, and diff them.
 --
---   psql -h "$SOURCE_HOST" -U postgres -d shop -f 05_reconcile.sql > /tmp/source.txt
---   psql -h "$TARGET_HOST" -U postgres -d shop -f 05_reconcile.sql > /tmp/target.txt
---   diff /tmp/source.txt /tmp/target.txt && echo "reconciled"
+--   psql -h "$SOURCE_HOST" -At -F'|' -f 05_reconcile.sql > /tmp/source.txt
+--   psql -h "$TARGET_HOST" -At -F'|' -f 05_reconcile.sql > /tmp/target.txt
+--   diff /tmp/source.txt /tmp/target.txt
+--
+-- A clean diff is NOT the pass condition once the application has been repointed: the
+-- target legitimately holds orders and order_items the source will never see. What must
+-- hold is that customers and products match exactly on both count and checksum, and that
+-- the target's counts for the two order tables are >= the source's. Module 04's reconcile
+-- step has the check that asserts exactly that; `diff` alone reports a difference that is
+-- expected and says nothing about whether it is acceptable.
 --
 -- A row count alone proves only that the right NUMBER of rows arrived. The per-table
 -- checksum proves the right rows arrived: sum(hashtext(...)) over a business column is

--- a/workshops/postgres_migration/sql/06_pg_clickhouse.sql
+++ b/workshops/postgres_migration/sql/06_pg_clickhouse.sql
@@ -102,7 +102,17 @@ GRANT USAGE ON SCHEMA ch TO shop_analytics;
 -- This creates foreign tables named after the ClickHouse tables the ClickPipe created:
 -- customers, products, orders, order_items. Nothing in `public` is touched. Add
 -- `LIMIT TO (...)` if the ClickHouse database holds more than the four.
+-- The IMPORT runs as whichever role executes this file, and Postgres requires THAT role to
+-- have its own user mapping -- the one created in step 3 is for shop_analytics and does not
+-- satisfy it. Create one for the duration of the import and drop it immediately after, so the
+-- only mapping that outlives this file is still shop_analytics's.
+CREATE USER MAPPING FOR CURRENT_USER
+  SERVER ch_srv
+  OPTIONS (user :'ch_user', password :'ch_password');
+
 IMPORT FOREIGN SCHEMA :"ch_database" FROM SERVER ch_srv INTO ch;
+
+DROP USER MAPPING FOR CURRENT_USER SERVER ch_srv;
 
 -- Grant AFTER the import, because the foreign tables did not exist until the line above
 -- ran, and IMPORT FOREIGN SCHEMA leaves them owned by the master user. Without this the
@@ -143,7 +153,7 @@ ALTER ROLE shop_analytics SET search_path = ch, public;
 -- ---------------------------------------------------------------------------
 -- Prove the routing per role, before trusting a dashboard panel.
 -- ---------------------------------------------------------------------------
--- Module 05 runs exactly these two. Both use the q1_revenue_by_hour.sql text verbatim, and
+-- Module 06 runs exactly these two. Both use the q1_revenue_by_hour.sql text verbatim, and
 -- the reconnect matters: `\c` starts a new session, which is when the role's search_path
 -- from step 6 is applied.
 --

--- a/workshops/postgres_migration/terraform/main.tf
+++ b/workshops/postgres_migration/terraform/main.tf
@@ -19,7 +19,7 @@ resource "aws_db_parameter_group" "shop" {
   family      = "postgres17"
   description = "Logical replication enabled so this instance can be a publication source."
 
-  # Static parameter: RDS requires an instance reboot before it takes effect. Module 03
+  # Static parameter: RDS requires an instance reboot before it takes effect. Module 01
   # verifies with `SHOW wal_level` returning `logical`.
   parameter {
     name         = "rds.logical_replication"


### PR DESCRIPTION
Two defects found by running the workshop end to end against real infrastructure, plus three stale comment references. Sibling to #99 and #100, no overlapping files.

## `06_pg_clickhouse.sql` could never complete

It creates a user mapping for `shop_analytics`, then runs `IMPORT FOREIGN SCHEMA`:

```
psql:sql/06_pg_clickhouse.sql:105: ERROR:  user mapping not found for user "postgres", server "ch_srv"
```

Postgres requires a mapping for the role **executing** the import, not for the role that will later read the tables. There was never one, so the import aborted and no foreign tables were created — while the `GRANT` and `ALTER ROLE` after it still printed success. The run looks almost fine; the failure only surfaces later as a routing step with nothing to route to.

Fixed with a mapping for `CURRENT_USER` around the import, dropped immediately after. That preserves the property the file's own comments depend on: when it finishes, `shop_analytics` is the only role with a ClickHouse identity and `shop_writer` still has none.

**Verified with `postgres_fdw` in a container**, since `pg_clickhouse` isn't available locally — same error before the change, and after it:

```
 foreign_table_schema | foreign_table_name      authorization_identifier
----------------------+--------------------     ------------------------
 ch                   | orders                  shop_analytics
```

## `05_reconcile.sql` documented a pass condition that cannot hold

Its header showed `diff … && echo "reconciled"`, which can never print once the application has been repointed: the target legitimately holds `orders` and `order_items` rows the source will never see. So the file told you to expect success on a condition that guarantees failure.

The header now states the real condition — `customers` and `products` identical on count and checksum, the two order tables greater-or-equal on the target — and the psql invocation moves to `-At -F'|'` so the output is machine-comparable by the check the playbook now runs.

## Stale comment references

- `05_reconcile.sql` and `06_pg_clickhouse.sql` named modules that moved when module 03 was split into Replicate and Cut over.
- `terraform/main.tf` credited module 03 with verifying `SHOW wal_level` after the parameter-group reboot. Module 01 does that, and always has — this one predates the split.

## Verification

- `terraform fmt -check` and `terraform validate` pass
- The `postgres_fdw` reproduction above, covering both the failure and the fix
- These files are authored in the private WorkshopHouse repo and mirrored here; both copies are byte-identical after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)